### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/quality-checks.yaml
+++ b/.github/workflows/quality-checks.yaml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Code Quality Check
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/hambosto/sweetbyte/security/code-scanning/4](https://github.com/hambosto/sweetbyte/security/code-scanning/4)

To fix the problem, we should add a `permissions` block to the workflow, either at the root level (to apply to all jobs) or to each job individually. Since none of the jobs require write access, the minimal required permission is `contents: read`, which allows jobs to check out code but not modify repository contents. The best way to fix this is to add the following block near the top of the workflow file, after the `name:` and before the `on:` block:

```yaml
permissions:
  contents: read
```

This will ensure that all jobs in the workflow only have read access to repository contents via the GITHUB_TOKEN, adhering to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
