### PR TITLE
refactor(header): restructure validation and verification

### DIFF
--- a/internal/header/deserializer.go
+++ b/internal/header/deserializer.go
@@ -1,3 +1,4 @@
+// Package header provides functionality for creating, reading, and writing file headers.
 package header
 
 import (
@@ -7,45 +8,58 @@ import (
 	"github.com/hambosto/sweetbyte/internal/utils"
 )
 
-// Deserializer handles deserializing headers from byte streams
+// Deserializer handles the process of converting a byte stream into a structured Header.
+// It includes validation to ensure the header is well-formed and conforms to expected values.
 type Deserializer struct {
-	data      []byte
-	offset    int
-	validator *Validator
+	data      []byte     // The raw byte slice containing the header data.
+	offset    int        // The current reading offset within the data slice.
+	validator *Validator // A validator to check the header's integrity after parsing.
 }
 
-// NewDeserializer creates a new Deserializer
+// NewDeserializer creates and returns a new Deserializer instance.
+// It initializes the necessary components, including the validator.
 func NewDeserializer() *Deserializer {
 	return &Deserializer{
 		validator: NewValidator(),
 	}
 }
 
-// Read reads a header from an io.Reader
+// Read consumes bytes from an io.Reader to construct a Header.
+// It reads the exact number of bytes required for a full header and then unmarshals them.
+// Returns an error if reading from the reader fails or is incomplete.
 func (d *Deserializer) Read(r io.Reader) (*Header, error) {
+	// Allocate a buffer of the precise size for the header.
 	data := make([]byte, TotalHeaderSize)
+	// Read the full header data from the input stream.
 	n, err := io.ReadFull(r, data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read header data: read %d of %d bytes: %w", n, TotalHeaderSize, err)
 	}
 
+	// Unmarshal the byte data into a Header struct.
 	return d.Unmarshal(data)
 }
 
-// Unmarshal unmarshals a header from a byte slice
+// Unmarshal parses a byte slice into a Header struct.
+// It performs a size check, parses the fields, and then validates the parsed header.
+// Returns an error if the data size is incorrect, parsing fails, or validation fails.
 func (d *Deserializer) Unmarshal(data []byte) (*Header, error) {
+	// Ensure the provided data is of the correct size for a header.
 	if len(data) != TotalHeaderSize {
 		return nil, fmt.Errorf("invalid header size: expected %d bytes, got %d", TotalHeaderSize, len(data))
 	}
 
+	// Reset the deserializer's state for the new data.
 	d.data = data
 	d.offset = 0
 
+	// Parse the byte data into the header fields.
 	header := &Header{}
 	if err := d.parseHeader(header); err != nil {
 		return nil, fmt.Errorf("header parsing failed: %w", err)
 	}
 
+	// Validate the header's contents after deserialization.
 	if err := d.validator.ValidateAfterDeserialization(header); err != nil {
 		return nil, fmt.Errorf("header validation failed: %w", err)
 	}
@@ -53,6 +67,8 @@ func (d *Deserializer) Unmarshal(data []byte) (*Header, error) {
 	return header, nil
 }
 
+// parseHeader extracts data from the byte slice and populates the fields of the Header struct.
+// It reads the header fields in the order they are defined in the specification.
 func (d *Deserializer) parseHeader(h *Header) error {
 	copy(h.magic[:], d.readBytes(MagicSize))
 	h.version = utils.FromBytes[uint16](d.readBytes(VersionSize))
@@ -66,10 +82,14 @@ func (d *Deserializer) parseHeader(h *Header) error {
 	return nil
 }
 
+// readBytes reads a specified number of bytes from the internal data slice and advances the offset.
+// It returns a new byte slice of the requested size, which will be zero-filled if the read goes out of bounds.
 func (d *Deserializer) readBytes(n int) []byte {
+	// Prevent panic on out-of-bounds read by returning a zeroed slice.
 	if d.offset+n > len(d.data) {
 		return make([]byte, n)
 	}
+	// Extract the slice and advance the internal offset.
 	result := d.data[d.offset : d.offset+n]
 	d.offset += n
 	return result

--- a/internal/header/deserializer.go
+++ b/internal/header/deserializer.go
@@ -1,4 +1,3 @@
-// Package header provides functionality for creating, reading, and writing file headers.
 package header
 
 import (
@@ -8,106 +7,68 @@ import (
 	"github.com/hambosto/sweetbyte/internal/utils"
 )
 
-// Deserializer handles deserializing a header from a byte stream.
+// Deserializer handles deserializing headers from byte streams
 type Deserializer struct {
-	data   []byte
-	offset int
+	data      []byte
+	offset    int
+	validator *Validator
 }
 
-// NewDeserializer creates a new Deserializer.
+// NewDeserializer creates a new Deserializer
 func NewDeserializer() *Deserializer {
-	return &Deserializer{}
+	return &Deserializer{
+		validator: NewValidator(),
+	}
 }
 
-// Read reads a header from an io.Reader.
+// Read reads a header from an io.Reader
 func (d *Deserializer) Read(r io.Reader) (*Header, error) {
-	// Read the header data from the reader.
 	data := make([]byte, TotalHeaderSize)
 	n, err := io.ReadFull(r, data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read header data: read %d of %d bytes: %w", n, TotalHeaderSize, err)
 	}
 
-	// Unmarshal the header data.
 	return d.Unmarshal(data)
 }
 
-// Unmarshal unmarshals a header from a byte slice.
+// Unmarshal unmarshals a header from a byte slice
 func (d *Deserializer) Unmarshal(data []byte) (*Header, error) {
-	// Check the header size.
 	if len(data) != TotalHeaderSize {
 		return nil, fmt.Errorf("invalid header size: expected %d bytes, got %d", TotalHeaderSize, len(data))
 	}
+
 	d.data = data
 	d.offset = 0
 
-	// Parse the header.
 	header := &Header{}
 	if err := d.parseHeader(header); err != nil {
 		return nil, fmt.Errorf("header parsing failed: %w", err)
 	}
 
-	// Validate the parsed header.
-	if err := d.validateParsedHeader(header); err != nil {
+	if err := d.validator.ValidateAfterDeserialization(header); err != nil {
 		return nil, fmt.Errorf("header validation failed: %w", err)
 	}
 
 	return header, nil
 }
 
-// parseHeader parses the header fields from the byte slice.
 func (d *Deserializer) parseHeader(h *Header) error {
 	copy(h.magic[:], d.readBytes(MagicSize))
-
 	h.version = utils.FromBytes[uint16](d.readBytes(VersionSize))
 	h.flags = utils.FromBytes[uint32](d.readBytes(FlagsSize))
 	copy(h.salt[:], d.readBytes(SaltSize))
-
 	h.originalSize = utils.FromBytes[uint64](d.readBytes(OriginalSizeSize))
 	copy(h.integrityHash[:], d.readBytes(IntegrityHashSize))
 	copy(h.authTag[:], d.readBytes(AuthTagSize))
-
 	h.checksum = utils.FromBytes[uint32](d.readBytes(ChecksumSize))
 	copy(h.padding[:], d.readBytes(PaddingSize))
-
 	return nil
 }
 
-// validateParsedHeader validates the parsed header fields.
-func (d *Deserializer) validateParsedHeader(h *Header) error {
-	// Validate the magic bytes.
-	if !utils.SecureCompare(h.magic[:], []byte(MagicBytes)) {
-		return fmt.Errorf("invalid magic bytes: expected %s, got %s", MagicBytes, string(h.magic[:]))
-	}
-
-	// Validate the version.
-	if h.version == 0 {
-		return fmt.Errorf("invalid version: cannot be zero")
-	}
-
-	if h.version > CurrentVersion {
-		return fmt.Errorf("unsupported version: %d (maximum supported: %d)", h.version, CurrentVersion)
-	}
-
-	// Validate the original size.
-	if h.originalSize == 0 {
-		return fmt.Errorf("invalid original size: cannot be zero")
-	}
-
-	// Validate the salt.
-	zeroSalt := make([]byte, SaltSize)
-	if utils.SecureCompare(h.salt[:], zeroSalt) {
-		return fmt.Errorf("invalid salt: all zeros detected")
-	}
-
-	return nil
-}
-
-// readBytes reads n bytes from the data slice.
 func (d *Deserializer) readBytes(n int) []byte {
 	if d.offset+n > len(d.data) {
-		result := make([]byte, n)
-		return result
+		return make([]byte, n)
 	}
 	result := d.data[d.offset : d.offset+n]
 	d.offset += n

--- a/internal/header/deserializer.go
+++ b/internal/header/deserializer.go
@@ -70,14 +70,23 @@ func (d *Deserializer) Unmarshal(data []byte) (*Header, error) {
 // parseHeader extracts data from the byte slice and populates the fields of the Header struct.
 // It reads the header fields in the order they are defined in the specification.
 func (d *Deserializer) parseHeader(h *Header) error {
+	// Parse the magic number, which identifies the file type.
 	copy(h.magic[:], d.readBytes(MagicSize))
+	// Parse the version of the header format.
 	h.version = utils.FromBytes[uint16](d.readBytes(VersionSize))
+	// Parse the flags that control encryption and compression options.
 	h.flags = utils.FromBytes[uint32](d.readBytes(FlagsSize))
+	// Parse the salt used in the key derivation process.
 	copy(h.salt[:], d.readBytes(SaltSize))
+	// Parse the original size of the file before any processing.
 	h.originalSize = utils.FromBytes[uint64](d.readBytes(OriginalSizeSize))
+	// Parse the hash of the original file to ensure integrity.
 	copy(h.integrityHash[:], d.readBytes(IntegrityHashSize))
+	// Parse the authentication tag for encrypted data.
 	copy(h.authTag[:], d.readBytes(AuthTagSize))
+	// Parse the checksum of the header itself.
 	h.checksum = utils.FromBytes[uint32](d.readBytes(ChecksumSize))
+	// Parse any padding bytes used to align the header.
 	copy(h.padding[:], d.readBytes(PaddingSize))
 	return nil
 }

--- a/internal/header/format_verifier.go
+++ b/internal/header/format_verifier.go
@@ -1,0 +1,75 @@
+package header
+
+import (
+	"fmt"
+
+	"github.com/hambosto/sweetbyte/internal/utils"
+)
+
+// FormatVerifier verifies header format compliance
+type FormatVerifier struct{}
+
+// NewFormatVerifier creates a new FormatVerifier
+func NewFormatVerifier() *FormatVerifier {
+	return &FormatVerifier{}
+}
+
+// Verify verifies the format of the header
+func (fv *FormatVerifier) Verify(h *Header) error {
+	if err := fv.verifyMagicBytes(h); err != nil {
+		return err
+	}
+	if err := fv.verifyVersion(h); err != nil {
+		return err
+	}
+	if err := fv.verifyOriginalSize(h); err != nil {
+		return err
+	}
+	if err := fv.verifySecurityFlags(h); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (fv *FormatVerifier) verifyMagicBytes(h *Header) error {
+	if !utils.SecureCompare(h.magic[:], []byte(MagicBytes)) {
+		return fmt.Errorf("invalid magic bytes: expected %s, got %s", MagicBytes, string(h.magic[:]))
+	}
+	return nil
+}
+
+func (fv *FormatVerifier) verifyVersion(h *Header) error {
+	if h.version == 0 {
+		return fmt.Errorf("invalid version: cannot be zero")
+	}
+	if h.version > CurrentVersion {
+		return fmt.Errorf("unsupported version: %d (maximum supported: %d)", h.version, CurrentVersion)
+	}
+	return nil
+}
+
+func (fv *FormatVerifier) verifyOriginalSize(h *Header) error {
+	if h.originalSize == 0 {
+		return fmt.Errorf("invalid original size: cannot be zero")
+	}
+	return nil
+}
+
+func (fv *FormatVerifier) verifySecurityFlags(h *Header) error {
+	requiredFlags := []struct {
+		flag uint32
+		name string
+	}{
+		{FlagEncrypted, "encryption"},
+		{FlagIntegrityV2, "integrity v2"},
+		{FlagAntiTamper, "anti-tamper"},
+	}
+
+	for _, rf := range requiredFlags {
+		if !h.HasFlag(rf.flag) {
+			return fmt.Errorf("%s flag not set - header created without maximum security", rf.name)
+		}
+	}
+
+	return nil
+}

--- a/internal/header/header.go
+++ b/internal/header/header.go
@@ -1,4 +1,6 @@
 // Package header provides functionality for creating, reading, and writing file headers.
+// This includes defining the header structure, handling serialization and deserialization,
+// and performing validation and verification to ensure integrity and authenticity.
 package header
 
 import (
@@ -7,66 +9,73 @@ import (
 	"io"
 )
 
-// Constants for header structure
+// Constants defining the structure and size of the file header.
 const (
-	MagicBytes        = "SWX4"
-	MagicSize         = 4
-	VersionSize       = 2
-	FlagsSize         = 4
-	SaltSize          = 32
-	OriginalSizeSize  = 8
-	IntegrityHashSize = 32
-	AuthTagSize       = 32
-	ChecksumSize      = 4
-	PaddingSize       = 16
-	TotalHeaderSize   = 134
+	MagicBytes        = "SWX4" // MagicBytes is a 4-byte sequence that identifies the file type.
+	MagicSize         = 4      // MagicSize is the size of the magic bytes.
+	VersionSize       = 2      // VersionSize is the size of the version field.
+	FlagsSize         = 4      // FlagsSize is the size of the flags field.
+	SaltSize          = 32     // SaltSize is the size of the salt used in key derivation.
+	OriginalSizeSize  = 8      // OriginalSizeSize is the size of the original file size field.
+	IntegrityHashSize = 32     // IntegrityHashSize is the size of the integrity hash.
+	AuthTagSize       = 32     // AuthTagSize is the size of the authentication tag.
+	ChecksumSize      = 4      // ChecksumSize is the size of the header checksum.
+	PaddingSize       = 16     // PaddingSize is the size of the random padding.
+	TotalHeaderSize   = 134    // TotalHeaderSize is the total size of the header in bytes.
 )
 
-// Version and flag constants
+// Version and flag constants for controlling file processing.
 const (
-	CurrentVersion  uint16 = 0x0001
-	FlagCompressed  uint32 = 1 << 0
-	FlagEncrypted   uint32 = 1 << 1
-	FlagIntegrityV2 uint32 = 1 << 2
-	FlagAntiTamper  uint32 = 1 << 3
-	DefaultFlags           = FlagEncrypted | FlagIntegrityV2 | FlagAntiTamper
+	CurrentVersion  uint16 = 0x0001 // CurrentVersion is the latest version of the header format.
+	FlagCompressed  uint32 = 1 << 0 // FlagCompressed indicates that the file content is compressed.
+	FlagEncrypted   uint32 = 1 << 1 // FlagEncrypted indicates that the file content is encrypted.
+	FlagIntegrityV2 uint32 = 1 << 2 // FlagIntegrityV2 indicates the use of a specific integrity checking mechanism.
+	FlagAntiTamper  uint32 = 1 << 3 // FlagAntiTamper indicates that anti-tampering measures are in place.
+	// DefaultFlags represents the standard set of flags applied to new headers.
+	DefaultFlags = FlagEncrypted | FlagIntegrityV2 | FlagAntiTamper
 )
 
-// Header represents the header of a SweetByte file.
+// Header represents the structured data at the beginning of a SweetByte file.
+// It contains metadata and security information essential for file processing.
+// The fields are private and accessed via getter methods to ensure immutability.
 type Header struct {
-	magic         [MagicSize]byte
-	version       uint16
-	flags         uint32
-	salt          [SaltSize]byte
-	originalSize  uint64
-	integrityHash [IntegrityHashSize]byte
-	authTag       [AuthTagSize]byte
-	checksum      uint32
-	padding       [PaddingSize]byte
+	magic         [MagicSize]byte         // Magic bytes to identify the file type.
+	version       uint16                  // Version of the header format.
+	flags         uint32                  // Flags indicating processing options (e.g., compression, encryption).
+	salt          [SaltSize]byte          // Salt for key derivation, enhancing security.
+	originalSize  uint64                  // Original size of the file before any processing.
+	integrityHash [IntegrityHashSize]byte // Hash of the header's structural components to detect corruption.
+	authTag       [AuthTagSize]byte       // Authentication tag to verify the header's authenticity.
+	checksum      uint32                  // Checksum of the entire header for a quick integrity check.
+	padding       [PaddingSize]byte       // Random padding to obscure the header size and prevent certain attacks.
 }
 
-// NewHeader creates a new Header with the given parameters
+// NewHeader creates a new Header with the given parameters.
+// It initializes the header with default values, generates random padding,
+// and computes all necessary protection fields (integrity hash, auth tag, checksum).
 func NewHeader(originalSize uint64, salt []byte, key []byte) (*Header, error) {
+	// Validate the input parameters before proceeding.
 	if err := validateNewHeaderParams(originalSize, salt, key); err != nil {
 		return nil, err
 	}
 
+	// Initialize the header with basic information.
 	header := &Header{
 		version:      CurrentVersion,
 		flags:        DefaultFlags,
 		originalSize: originalSize,
 	}
 
-	// Set magic bytes and salt
+	// Set the magic bytes and the provided salt.
 	copy(header.magic[:], []byte(MagicBytes))
 	copy(header.salt[:], salt)
 
-	// Generate random padding
+	// Generate random data for the padding field.
 	if err := generatePadding(header); err != nil {
 		return nil, err
 	}
 
-	// Compute protection fields
+	// Compute and set the integrity hash, authentication tag, and checksum.
 	protector := NewProtector(key)
 	if err := protector.ComputeAllProtection(header); err != nil {
 		return nil, fmt.Errorf("failed to compute protection: %w", err)
@@ -75,54 +84,62 @@ func NewHeader(originalSize uint64, salt []byte, key []byte) (*Header, error) {
 	return header, nil
 }
 
-// Read reads a header from an io.Reader
+// Read deserializes a header from an io.Reader.
+// It uses a Deserializer to handle the reading and parsing process.
 func Read(r io.Reader) (*Header, error) {
 	deserializer := NewDeserializer()
 	return deserializer.Read(r)
 }
 
-// Write writes the header to an io.Writer
+// Write serializes the header to an io.Writer.
+// It uses a Serializer to handle the writing process.
 func (h *Header) Write(w io.Writer) error {
 	serializer := NewSerializer()
 	return serializer.Write(w, h)
 }
 
-// Verify verifies the header's integrity and authenticity
+// Verify checks the integrity and authenticity of the header using a provided key.
+// It uses a Verifier to perform a comprehensive set of checks.
 func (h *Header) Verify(key []byte) error {
 	verifier := NewVerifier(key)
 	return verifier.VerifyAll(h)
 }
 
-// Getter methods
+// Magic returns a copy of the magic bytes.
 func (h *Header) Magic() []byte {
 	result := make([]byte, MagicSize)
 	copy(result, h.magic[:])
 	return result
 }
 
+// Version returns the header version.
 func (h *Header) Version() uint16 {
 	return h.version
 }
 
+// Flags returns the header flags.
 func (h *Header) Flags() uint32 {
 	return h.flags
 }
 
+// Salt returns a copy of the salt.
 func (h *Header) Salt() []byte {
 	result := make([]byte, SaltSize)
 	copy(result, h.salt[:])
 	return result
 }
 
+// OriginalSize returns the original size of the file.
 func (h *Header) OriginalSize() uint64 {
 	return h.originalSize
 }
 
+// HasFlag checks if a specific flag is set in the header.
 func (h *Header) HasFlag(flag uint32) bool {
 	return h.flags&flag != 0
 }
 
-// Helper functions for header creation
+// validateNewHeaderParams ensures that the parameters for creating a new header are valid.
 func validateNewHeaderParams(originalSize uint64, salt []byte, key []byte) error {
 	if len(salt) != SaltSize {
 		return fmt.Errorf("salt must be exactly %d bytes", SaltSize)
@@ -136,6 +153,7 @@ func validateNewHeaderParams(originalSize uint64, salt []byte, key []byte) error
 	return nil
 }
 
+// generatePadding fills the header's padding field with random bytes.
 func generatePadding(header *Header) error {
 	if _, err := rand.Read(header.padding[:]); err != nil {
 		return fmt.Errorf("failed to generate padding: %w", err)

--- a/internal/header/header.go
+++ b/internal/header/header.go
@@ -7,44 +7,29 @@ import (
 	"io"
 )
 
+// Constants for header structure
 const (
-	// MagicBytes is the magic byte sequence for SweetByte files.
-	MagicBytes = "SWX4"
-	// MagicSize is the size of the magic byte sequence.
-	MagicSize = 4
-	// VersionSize is the size of the version field.
-	VersionSize = 2
-	// FlagsSize is the size of the flags field.
-	FlagsSize = 4
-	// SaltSize is the size of the salt field.
-	SaltSize = 32
-	// OriginalSizeSize is the size of the original size field.
-	OriginalSizeSize = 8
-	// IntegrityHashSize is the size of the integrity hash field.
+	MagicBytes        = "SWX4"
+	MagicSize         = 4
+	VersionSize       = 2
+	FlagsSize         = 4
+	SaltSize          = 32
+	OriginalSizeSize  = 8
 	IntegrityHashSize = 32
-	// AuthTagSize is the size of the authentication tag field.
-	AuthTagSize = 32
-	// ChecksumSize is the size of the checksum field.
-	ChecksumSize = 4
-	// PaddingSize is the size of the padding field.
-	PaddingSize = 16
-	// TotalHeaderSize is the total size of the header.
-	TotalHeaderSize = 134
+	AuthTagSize       = 32
+	ChecksumSize      = 4
+	PaddingSize       = 16
+	TotalHeaderSize   = 134
 )
 
+// Version and flag constants
 const (
-	// CurrentVersion is the current version of the file format.
-	CurrentVersion uint16 = 0x0001
-	// FlagCompressed indicates that the file is compressed.
-	FlagCompressed uint32 = 1 << 0
-	// FlagEncrypted indicates that the file is encrypted.
-	FlagEncrypted uint32 = 1 << 1
-	// FlagIntegrityV2 indicates that the file uses the v2 integrity check.
+	CurrentVersion  uint16 = 0x0001
+	FlagCompressed  uint32 = 1 << 0
+	FlagEncrypted   uint32 = 1 << 1
 	FlagIntegrityV2 uint32 = 1 << 2
-	// FlagAntiTamper indicates that the file has anti-tampering protection.
-	FlagAntiTamper uint32 = 1 << 3
-	// DefaultFlags is the default set of flags for a new file.
-	DefaultFlags = FlagEncrypted | FlagIntegrityV2 | FlagAntiTamper
+	FlagAntiTamper  uint32 = 1 << 3
+	DefaultFlags           = FlagEncrypted | FlagIntegrityV2 | FlagAntiTamper
 )
 
 // Header represents the header of a SweetByte file.
@@ -60,92 +45,100 @@ type Header struct {
 	padding       [PaddingSize]byte
 }
 
-// NewHeader creates a new Header.
+// NewHeader creates a new Header with the given parameters
 func NewHeader(originalSize uint64, salt []byte, key []byte) (*Header, error) {
-	// Validate the input parameters.
-	if len(salt) != SaltSize {
-		return nil, fmt.Errorf("salt must be exactly %d bytes", SaltSize)
-	}
-	if len(key) == 0 {
-		return nil, fmt.Errorf("key cannot be empty")
-	}
-	if originalSize == 0 {
-		return nil, fmt.Errorf("original size cannot be zero")
+	if err := validateNewHeaderParams(originalSize, salt, key); err != nil {
+		return nil, err
 	}
 
-	// Create a new header with default values.
-	h := &Header{
+	header := &Header{
 		version:      CurrentVersion,
 		flags:        DefaultFlags,
 		originalSize: originalSize,
 	}
 
-	// Set the magic bytes and salt.
-	copy(h.magic[:], []byte(MagicBytes))
-	copy(h.salt[:], salt)
+	// Set magic bytes and salt
+	copy(header.magic[:], []byte(MagicBytes))
+	copy(header.salt[:], salt)
 
-	// Generate random padding.
-	if _, err := rand.Read(h.padding[:]); err != nil {
-		return nil, fmt.Errorf("failed to generate padding: %w", err)
+	// Generate random padding
+	if err := generatePadding(header); err != nil {
+		return nil, err
 	}
 
-	// Compute the protection fields.
+	// Compute protection fields
 	protector := NewProtector(key)
-	if err := protector.ComputeAllProtection(h); err != nil {
+	if err := protector.ComputeAllProtection(header); err != nil {
 		return nil, fmt.Errorf("failed to compute protection: %w", err)
 	}
 
-	return h, nil
+	return header, nil
 }
 
-// Read reads a header from an io.Reader.
+// Read reads a header from an io.Reader
 func Read(r io.Reader) (*Header, error) {
 	deserializer := NewDeserializer()
 	return deserializer.Read(r)
 }
 
-// Write writes the header to an io.Writer.
+// Write writes the header to an io.Writer
 func (h *Header) Write(w io.Writer) error {
 	serializer := NewSerializer()
 	return serializer.Write(w, h)
 }
 
-// Verify verifies the header's integrity and authenticity.
+// Verify verifies the header's integrity and authenticity
 func (h *Header) Verify(key []byte) error {
 	verifier := NewVerifier(key)
 	return verifier.VerifyAll(h)
 }
 
-// Magic returns the magic bytes of the header.
+// Getter methods
 func (h *Header) Magic() []byte {
 	result := make([]byte, MagicSize)
 	copy(result, h.magic[:])
 	return result
 }
 
-// Version returns the version of the header.
 func (h *Header) Version() uint16 {
 	return h.version
 }
 
-// Flags returns the flags of the header.
 func (h *Header) Flags() uint32 {
 	return h.flags
 }
 
-// Salt returns the salt of the header.
 func (h *Header) Salt() []byte {
 	result := make([]byte, SaltSize)
 	copy(result, h.salt[:])
 	return result
 }
 
-// OriginalSize returns the original size of the file.
 func (h *Header) OriginalSize() uint64 {
 	return h.originalSize
 }
 
-// HasFlag checks if the header has a specific flag set.
 func (h *Header) HasFlag(flag uint32) bool {
 	return h.flags&flag != 0
+}
+
+// Helper functions for header creation
+func validateNewHeaderParams(originalSize uint64, salt []byte, key []byte) error {
+	if len(salt) != SaltSize {
+		return fmt.Errorf("salt must be exactly %d bytes", SaltSize)
+	}
+	if len(key) == 0 {
+		return fmt.Errorf("key cannot be empty")
+	}
+	if originalSize == 0 {
+		return fmt.Errorf("original size cannot be zero")
+	}
+	return nil
+}
+
+func generatePadding(header *Header) error {
+	if _, err := rand.Read(header.padding[:]); err != nil {
+		return fmt.Errorf("failed to generate padding: %w", err)
+	}
+	return nil
 }

--- a/internal/header/integrity_verifier.go
+++ b/internal/header/integrity_verifier.go
@@ -1,3 +1,4 @@
+// Package header provides functionality for creating, reading, and writing file headers.
 package header
 
 import (
@@ -7,24 +8,28 @@ import (
 	"github.com/hambosto/sweetbyte/internal/utils"
 )
 
-// ChecksumVerifier verifies header checksums
+// ChecksumVerifier is responsible for verifying the header's checksum.
+// The checksum provides a basic, non-cryptographic integrity check of the entire header.
 type ChecksumVerifier struct {
-	key []byte
+	key []byte // The key is used to recompute the expected checksum.
 }
 
-// NewChecksumVerifier creates a new ChecksumVerifier
+// NewChecksumVerifier creates a new ChecksumVerifier with the given key.
 func NewChecksumVerifier(key []byte) *ChecksumVerifier {
 	return &ChecksumVerifier{key: key}
 }
 
-// Verify verifies the checksum of the header
+// Verify computes the expected checksum of the header and compares it to the stored checksum.
+// It returns an error if the checksums do not match.
 func (cv *ChecksumVerifier) Verify(header *Header) error {
+	// Recompute the checksum using the same logic as in Protector.
 	protector := NewProtector(cv.key)
 	expected, err := protector.ComputeChecksum(header)
 	if err != nil {
 		return fmt.Errorf("failed to compute expected checksum: %w", err)
 	}
 
+	// Compare the stored checksum with the recomputed one.
 	if header.checksum != expected {
 		return fmt.Errorf("checksum mismatch: expected %08x, got %08x", expected, header.checksum)
 	}
@@ -32,24 +37,28 @@ func (cv *ChecksumVerifier) Verify(header *Header) error {
 	return nil
 }
 
-// IntegrityVerifier verifies header integrity
+// IntegrityVerifier is responsible for verifying the header's integrity hash.
+// This hash protects the structural parts of the header from tampering.
 type IntegrityVerifier struct {
-	key []byte
+	key []byte // The key is used for consistency with other verifiers, though not directly used here.
 }
 
-// NewIntegrityVerifier creates a new IntegrityVerifier
+// NewIntegrityVerifier creates a new IntegrityVerifier.
 func NewIntegrityVerifier(key []byte) *IntegrityVerifier {
 	return &IntegrityVerifier{key: key}
 }
 
-// Verify verifies the integrity of the header
+// Verify computes the expected integrity hash and compares it to the stored hash.
+// It uses a secure comparison to prevent timing attacks.
 func (iv *IntegrityVerifier) Verify(header *Header) error {
+	// Recompute the integrity hash.
 	protector := NewProtector(iv.key)
 	expected, err := protector.ComputeIntegrityHash(header)
 	if err != nil {
 		return fmt.Errorf("failed to compute expected integrity hash: %w", err)
 	}
 
+	// Securely compare the stored hash with the recomputed one.
 	if !utils.SecureCompare(header.integrityHash[:], expected) {
 		return fmt.Errorf("integrity hash verification failed - tampering detected")
 	}
@@ -57,28 +66,33 @@ func (iv *IntegrityVerifier) Verify(header *Header) error {
 	return nil
 }
 
-// AuthVerifier verifies header authentication
+// AuthVerifier is responsible for verifying the header's authentication tag.
+// The auth tag ensures both integrity and authenticity of the header, given a secret key.
 type AuthVerifier struct {
-	key []byte
+	key []byte // The secret key required to verify the HMAC-based authentication tag.
 }
 
-// NewAuthVerifier creates a new AuthVerifier
+// NewAuthVerifier creates a new AuthVerifier with the given key.
 func NewAuthVerifier(key []byte) *AuthVerifier {
 	return &AuthVerifier{key: key}
 }
 
-// Verify verifies the authentication of the header
+// Verify computes the expected authentication tag and compares it to the stored tag.
+// It uses a constant-time comparison to prevent timing attacks.
 func (av *AuthVerifier) Verify(header *Header) error {
+	// A key is mandatory for authentication.
 	if len(av.key) == 0 {
 		return fmt.Errorf("key required for authentication verification")
 	}
 
+	// Recompute the authentication tag.
 	protector := NewProtector(av.key)
 	expected, err := protector.ComputeAuthTag(header)
 	if err != nil {
 		return fmt.Errorf("failed to compute expected auth tag: %w", err)
 	}
 
+	// Use HMAC's constant-time comparison for security.
 	if !hmac.Equal(header.authTag[:], expected) {
 		return fmt.Errorf("authentication verification failed - invalid key or tampering detected")
 	}

--- a/internal/header/integrity_verifier.go
+++ b/internal/header/integrity_verifier.go
@@ -1,0 +1,87 @@
+package header
+
+import (
+	"crypto/hmac"
+	"fmt"
+
+	"github.com/hambosto/sweetbyte/internal/utils"
+)
+
+// ChecksumVerifier verifies header checksums
+type ChecksumVerifier struct {
+	key []byte
+}
+
+// NewChecksumVerifier creates a new ChecksumVerifier
+func NewChecksumVerifier(key []byte) *ChecksumVerifier {
+	return &ChecksumVerifier{key: key}
+}
+
+// Verify verifies the checksum of the header
+func (cv *ChecksumVerifier) Verify(header *Header) error {
+	protector := NewProtector(cv.key)
+	expected, err := protector.ComputeChecksum(header)
+	if err != nil {
+		return fmt.Errorf("failed to compute expected checksum: %w", err)
+	}
+
+	if header.checksum != expected {
+		return fmt.Errorf("checksum mismatch: expected %08x, got %08x", expected, header.checksum)
+	}
+
+	return nil
+}
+
+// IntegrityVerifier verifies header integrity
+type IntegrityVerifier struct {
+	key []byte
+}
+
+// NewIntegrityVerifier creates a new IntegrityVerifier
+func NewIntegrityVerifier(key []byte) *IntegrityVerifier {
+	return &IntegrityVerifier{key: key}
+}
+
+// Verify verifies the integrity of the header
+func (iv *IntegrityVerifier) Verify(header *Header) error {
+	protector := NewProtector(iv.key)
+	expected, err := protector.ComputeIntegrityHash(header)
+	if err != nil {
+		return fmt.Errorf("failed to compute expected integrity hash: %w", err)
+	}
+
+	if !utils.SecureCompare(header.integrityHash[:], expected) {
+		return fmt.Errorf("integrity hash verification failed - tampering detected")
+	}
+
+	return nil
+}
+
+// AuthVerifier verifies header authentication
+type AuthVerifier struct {
+	key []byte
+}
+
+// NewAuthVerifier creates a new AuthVerifier
+func NewAuthVerifier(key []byte) *AuthVerifier {
+	return &AuthVerifier{key: key}
+}
+
+// Verify verifies the authentication of the header
+func (av *AuthVerifier) Verify(header *Header) error {
+	if len(av.key) == 0 {
+		return fmt.Errorf("key required for authentication verification")
+	}
+
+	protector := NewProtector(av.key)
+	expected, err := protector.ComputeAuthTag(header)
+	if err != nil {
+		return fmt.Errorf("failed to compute expected auth tag: %w", err)
+	}
+
+	if !hmac.Equal(header.authTag[:], expected) {
+		return fmt.Errorf("authentication verification failed - invalid key or tampering detected")
+	}
+
+	return nil
+}

--- a/internal/header/protector.go
+++ b/internal/header/protector.go
@@ -1,3 +1,4 @@
+// Package header provides functionality for creating, reading, and writing file headers.
 package header
 
 import (
@@ -10,31 +11,38 @@ import (
 	"github.com/hambosto/sweetbyte/internal/utils"
 )
 
-// Protector computes protection fields for headers
+// Protector is responsible for computing the cryptographic and checksum fields of a header.
+// This includes the integrity hash, authentication tag, and checksum, which protect
+// the header against tampering and corruption.
 type Protector struct {
-	key []byte
+	key []byte // The secret key used for generating the authentication tag.
 }
 
-// NewProtector creates a new Protector
+// NewProtector creates a new Protector instance with the given key.
 func NewProtector(key []byte) *Protector {
 	return &Protector{key: key}
 }
 
-// ComputeAllProtection computes all protection fields for the header
+// ComputeAllProtection orchestrates the computation of all protection fields for the header.
+// It calls the individual computation methods for integrity hash, auth tag, and checksum.
 func (p *Protector) ComputeAllProtection(header *Header) error {
+	// Compute and set the integrity hash.
 	if err := p.computeIntegrityHash(header); err != nil {
 		return fmt.Errorf("integrity hash computation failed: %w", err)
 	}
+	// Compute and set the authentication tag.
 	if err := p.computeAuthTag(header); err != nil {
 		return fmt.Errorf("auth tag computation failed: %w", err)
 	}
+	// Compute and set the checksum.
 	if err := p.computeChecksum(header); err != nil {
 		return fmt.Errorf("checksum computation failed: %w", err)
 	}
 	return nil
 }
 
-// ComputeIntegrityHash computes and returns the integrity hash
+// ComputeIntegrityHash calculates and returns the SHA-256 hash of the header's structural data.
+// This hash protects against unintentional corruption of the main header fields.
 func (p *Protector) ComputeIntegrityHash(header *Header) ([]byte, error) {
 	hasher := sha256.New()
 	if err := p.writeStructuralData(hasher, header); err != nil {
@@ -43,21 +51,27 @@ func (p *Protector) ComputeIntegrityHash(header *Header) ([]byte, error) {
 	return hasher.Sum(nil), nil
 }
 
-// ComputeAuthTag computes and returns the authentication tag
+// ComputeAuthTag calculates and returns the HMAC-SHA256 authentication tag.
+// This tag provides authenticity and integrity for the header, verifiable with a secret key.
 func (p *Protector) ComputeAuthTag(header *Header) ([]byte, error) {
+	// An authentication key is required.
 	if len(p.key) == 0 {
 		return nil, fmt.Errorf("key required for authentication tag")
 	}
 
+	// Create a new HMAC with SHA-256.
 	mac := hmac.New(sha256.New, p.key)
+	// Write the core structural data to the HMAC.
 	if err := p.writeStructuralData(mac, header); err != nil {
 		return nil, fmt.Errorf("failed to write structural data: %w", err)
 	}
 
+	// Include the integrity hash in the HMAC computation.
 	if _, err := mac.Write(header.integrityHash[:]); err != nil {
 		return nil, fmt.Errorf("failed to write integrity hash: %w", err)
 	}
 
+	// Include the padding in the HMAC computation.
 	if _, err := mac.Write(header.padding[:]); err != nil {
 		return nil, fmt.Errorf("failed to write padding: %w", err)
 	}
@@ -65,7 +79,8 @@ func (p *Protector) ComputeAuthTag(header *Header) ([]byte, error) {
 	return mac.Sum(nil), nil
 }
 
-// ComputeChecksum computes and returns the checksum
+// ComputeChecksum calculates and returns the CRC32 checksum of the entire header.
+// This provides a fast, non-cryptographic way to detect accidental data corruption.
 func (p *Protector) ComputeChecksum(header *Header) (uint32, error) {
 	crc := crc32.NewIEEE()
 	if err := p.writeDataForChecksum(crc, header); err != nil {
@@ -74,6 +89,7 @@ func (p *Protector) ComputeChecksum(header *Header) (uint32, error) {
 	return crc.Sum32(), nil
 }
 
+// computeIntegrityHash is an internal helper that computes the integrity hash and sets it on the header.
 func (p *Protector) computeIntegrityHash(header *Header) error {
 	hash, err := p.ComputeIntegrityHash(header)
 	if err != nil {
@@ -83,6 +99,7 @@ func (p *Protector) computeIntegrityHash(header *Header) error {
 	return nil
 }
 
+// computeAuthTag is an internal helper that computes the auth tag and sets it on the header.
 func (p *Protector) computeAuthTag(header *Header) error {
 	tag, err := p.ComputeAuthTag(header)
 	if err != nil {
@@ -92,6 +109,7 @@ func (p *Protector) computeAuthTag(header *Header) error {
 	return nil
 }
 
+// computeChecksum is an internal helper that computes the checksum and sets it on the header.
 func (p *Protector) computeChecksum(header *Header) error {
 	checksum, err := p.ComputeChecksum(header)
 	if err != nil {
@@ -101,6 +119,8 @@ func (p *Protector) computeChecksum(header *Header) error {
 	return nil
 }
 
+// writeStructuralData writes the core, non-protection fields of the header to an io.Writer.
+// This data is used for both the integrity hash and the authentication tag.
 func (p *Protector) writeStructuralData(w io.Writer, header *Header) error {
 	fields := [][]byte{
 		header.magic[:],
@@ -118,11 +138,15 @@ func (p *Protector) writeStructuralData(w io.Writer, header *Header) error {
 	return nil
 }
 
+// writeDataForChecksum writes all header data, including protection fields, to an io.Writer.
+// This is used for calculating the final checksum of the entire header.
 func (p *Protector) writeDataForChecksum(w io.Writer, header *Header) error {
+	// First, write the structural data.
 	if err := p.writeStructuralData(w, header); err != nil {
 		return err
 	}
 
+	// Then, write the protection fields.
 	fields := [][]byte{
 		header.integrityHash[:],
 		header.authTag[:],

--- a/internal/header/security_verifier.go
+++ b/internal/header/security_verifier.go
@@ -1,0 +1,139 @@
+package header
+
+import (
+	"fmt"
+
+	"github.com/hambosto/sweetbyte/internal/utils"
+)
+
+// TamperVerifier verifies anti-tampering measures
+type TamperVerifier struct{}
+
+// NewTamperVerifier creates a new TamperVerifier
+func NewTamperVerifier() *TamperVerifier {
+	return &TamperVerifier{}
+}
+
+// Verify verifies the anti-tampering measures of the header
+func (tv *TamperVerifier) Verify(h *Header) error {
+	fields := []struct {
+		data []byte
+		name string
+	}{
+		{h.salt[:], "salt"},
+		{h.padding[:], "padding"},
+		{h.integrityHash[:], "integrity hash"},
+		{h.authTag[:], "auth tag"},
+	}
+
+	for _, field := range fields {
+		if tv.isAllZeros(field.data) {
+			return fmt.Errorf("invalid %s: all zeros detected - possible tampering", field.name)
+		}
+	}
+
+	return nil
+}
+
+func (tv *TamperVerifier) isAllZeros(data []byte) bool {
+	zeroData := make([]byte, len(data))
+	return utils.SecureCompare(data, zeroData)
+}
+
+// PatternVerifier verifies security patterns
+type PatternVerifier struct{}
+
+// NewPatternVerifier creates a new PatternVerifier
+func NewPatternVerifier() *PatternVerifier {
+	return &PatternVerifier{}
+}
+
+// Verify verifies the security patterns of the header
+func (pv *PatternVerifier) Verify(h *Header) error {
+	fields := []struct {
+		data      []byte
+		name      string
+		minUnique int
+	}{
+		{h.salt[:], "salt", SaltSize / 4},
+		{h.padding[:], "padding", PaddingSize / 4},
+	}
+
+	for _, field := range fields {
+		if err := pv.checkForRepeatingBytes(field.data, field.name); err != nil {
+			return err
+		}
+		if err := pv.validateEntropy(field.data, field.name, field.minUnique); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (pv *PatternVerifier) checkForRepeatingBytes(data []byte, fieldName string) error {
+	if len(data) < 4 {
+		return nil
+	}
+
+	// Check if all bytes are the same
+	first := data[0]
+	allSame := true
+	for _, b := range data {
+		if b != first {
+			allSame = false
+			break
+		}
+	}
+
+	if allSame {
+		return fmt.Errorf("suspicious %s: all bytes identical (0x%02x) - possible tampering", fieldName, first)
+	}
+
+	// Check for simple patterns
+	if pv.hasSimplePattern(data) {
+		return fmt.Errorf("suspicious %s: sequential pattern detected - possible tampering", fieldName)
+	}
+
+	return nil
+}
+
+func (pv *PatternVerifier) hasSimplePattern(data []byte) bool {
+	if len(data) < 4 {
+		return false
+	}
+
+	// Check for ascending pattern
+	ascending := true
+	for i := 1; i < len(data) && i < 8; i++ {
+		if data[i] != data[i-1]+1 {
+			ascending = false
+			break
+		}
+	}
+
+	// Check for descending pattern
+	descending := true
+	for i := 1; i < len(data) && i < 8; i++ {
+		if data[i] != data[i-1]-1 {
+			descending = false
+			break
+		}
+	}
+
+	return ascending || descending
+}
+
+func (pv *PatternVerifier) validateEntropy(data []byte, fieldName string, minUnique int) error {
+	uniqueBytes := make(map[byte]bool)
+	for _, b := range data {
+		uniqueBytes[b] = true
+	}
+
+	if len(uniqueBytes) < minUnique {
+		return fmt.Errorf("insufficient entropy in %s: only %d unique bytes (minimum: %d) - possible weak generation",
+			fieldName, len(uniqueBytes), minUnique)
+	}
+
+	return nil
+}

--- a/internal/header/serializer.go
+++ b/internal/header/serializer.go
@@ -1,3 +1,4 @@
+// Package header provides functionality for creating, reading, and writing file headers.
 package header
 
 import (
@@ -7,30 +8,37 @@ import (
 	"github.com/hambosto/sweetbyte/internal/utils"
 )
 
-// Serializer handles serializing headers to byte streams
+// Serializer handles the conversion of a structured Header into a byte stream.
+// It ensures that the header is valid before serialization.
 type Serializer struct {
-	validator *Validator
+	validator *Validator // A validator to check the header's integrity before writing.
 }
 
-// NewSerializer creates a new Serializer
+// NewSerializer creates and returns a new Serializer instance.
 func NewSerializer() *Serializer {
 	return &Serializer{
 		validator: NewValidator(),
 	}
 }
 
-// Write writes a header to an io.Writer
+// Write serializes a Header and writes it to an io.Writer.
+// It first validates the header, then marshals it into a byte slice, and finally writes the data.
+// Returns an error if validation, writing, or the write operation itself fails.
 func (s *Serializer) Write(w io.Writer, header *Header) error {
+	// Validate the header to ensure all fields are correctly populated before serialization.
 	if err := s.validator.ValidateForSerialization(header); err != nil {
 		return fmt.Errorf("serialization validation failed: %w", err)
 	}
 
+	// Convert the Header struct to its byte representation.
 	data := s.Marshal(header)
+	// Write the byte data to the output stream.
 	n, err := w.Write(data)
 	if err != nil {
 		return fmt.Errorf("failed to write header data: %w", err)
 	}
 
+	// Check that the entire header was written.
 	if n != len(data) {
 		return fmt.Errorf("incomplete write: expected %d bytes, wrote %d", len(data), n)
 	}
@@ -38,10 +46,13 @@ func (s *Serializer) Write(w io.Writer, header *Header) error {
 	return nil
 }
 
-// Marshal marshals a header to a byte slice
+// Marshal converts a Header struct into a byte slice.
+// It concatenates the header fields in the correct order to produce the final byte representation.
 func (s *Serializer) Marshal(h *Header) []byte {
+	// Pre-allocate a slice with the exact size of the header for efficiency.
 	data := make([]byte, 0, TotalHeaderSize)
 
+	// Append each field to the byte slice in the specified order.
 	data = append(data, h.magic[:]...)
 	data = append(data, utils.ToBytes(h.version)...)
 	data = append(data, utils.ToBytes(h.flags)...)

--- a/internal/header/validator.go
+++ b/internal/header/validator.go
@@ -1,3 +1,4 @@
+// Package header provides functionality for creating, reading, and writing file headers.
 package header
 
 import (
@@ -6,16 +7,20 @@ import (
 	"github.com/hambosto/sweetbyte/internal/utils"
 )
 
-// Validator validates header fields
+// Validator is responsible for performing integrity checks on header fields.
+// It is used at different stages of the header's lifecycle, such as before serialization
+// and after deserialization, to ensure that the header's contents are valid.
 type Validator struct{}
 
-// NewValidator creates a new Validator
+// NewValidator creates and returns a new Validator instance.
 func NewValidator() *Validator {
 	return &Validator{}
 }
 
-// ValidateForSerialization validates header fields before serialization
+// ValidateForSerialization checks the header fields just before it is written to a stream.
+// This ensures that all computed fields (like hashes and tags) are present and valid.
 func (v *Validator) ValidateForSerialization(h *Header) error {
+	// A list of validation functions to be executed in order.
 	validators := []func(*Header) error{
 		v.validateMagicBytes,
 		v.validateVersion,
@@ -25,6 +30,7 @@ func (v *Validator) ValidateForSerialization(h *Header) error {
 		v.validateAuthTag,
 	}
 
+	// Execute each validator and return immediately on the first error.
 	for _, validator := range validators {
 		if err := validator(h); err != nil {
 			return err
@@ -34,8 +40,10 @@ func (v *Validator) ValidateForSerialization(h *Header) error {
 	return nil
 }
 
-// ValidateAfterDeserialization validates header fields after deserialization
+// ValidateAfterDeserialization checks the header fields immediately after it has been read from a stream.
+// This focuses on the fields that are not dependent on cryptographic verification.
 func (v *Validator) ValidateAfterDeserialization(h *Header) error {
+	// A list of validation functions for the initial check after reading.
 	validators := []func(*Header) error{
 		v.validateMagicBytes,
 		v.validateVersion,
@@ -43,6 +51,7 @@ func (v *Validator) ValidateAfterDeserialization(h *Header) error {
 		v.validateSalt,
 	}
 
+	// Execute each validator and return on the first error.
 	for _, validator := range validators {
 		if err := validator(h); err != nil {
 			return err
@@ -52,6 +61,7 @@ func (v *Validator) ValidateAfterDeserialization(h *Header) error {
 	return nil
 }
 
+// validateMagicBytes ensures that the magic bytes of the header are correct.
 func (v *Validator) validateMagicBytes(h *Header) error {
 	if !utils.SecureCompare(h.magic[:], []byte(MagicBytes)) {
 		return fmt.Errorf("invalid magic bytes: expected %s, got %s", MagicBytes, string(h.magic[:]))
@@ -59,6 +69,7 @@ func (v *Validator) validateMagicBytes(h *Header) error {
 	return nil
 }
 
+// validateVersion checks that the header version is supported.
 func (v *Validator) validateVersion(h *Header) error {
 	if h.version == 0 {
 		return fmt.Errorf("invalid version: cannot be zero")
@@ -69,6 +80,7 @@ func (v *Validator) validateVersion(h *Header) error {
 	return nil
 }
 
+// validateOriginalSize ensures that the original size is a non-zero value.
 func (v *Validator) validateOriginalSize(h *Header) error {
 	if h.originalSize == 0 {
 		return fmt.Errorf("invalid original size: cannot be zero")
@@ -76,18 +88,22 @@ func (v *Validator) validateOriginalSize(h *Header) error {
 	return nil
 }
 
+// validateSalt checks that the salt field is not all zeros.
 func (v *Validator) validateSalt(h *Header) error {
 	return v.validateNonZeroField(h.salt[:], "salt")
 }
 
+// validateIntegrityHash checks that the integrity hash field is not all zeros.
 func (v *Validator) validateIntegrityHash(h *Header) error {
 	return v.validateNonZeroField(h.integrityHash[:], "integrity hash")
 }
 
+// validateAuthTag checks that the authentication tag field is not all zeros.
 func (v *Validator) validateAuthTag(h *Header) error {
 	return v.validateNonZeroField(h.authTag[:], "auth tag")
 }
 
+// validateNonZeroField is a generic helper to check if a byte slice is all zeros.
 func (v *Validator) validateNonZeroField(field []byte, fieldName string) error {
 	zeroField := make([]byte, len(field))
 	if utils.SecureCompare(field, zeroField) {

--- a/internal/header/validator.go
+++ b/internal/header/validator.go
@@ -1,0 +1,97 @@
+package header
+
+import (
+	"fmt"
+
+	"github.com/hambosto/sweetbyte/internal/utils"
+)
+
+// Validator validates header fields
+type Validator struct{}
+
+// NewValidator creates a new Validator
+func NewValidator() *Validator {
+	return &Validator{}
+}
+
+// ValidateForSerialization validates header fields before serialization
+func (v *Validator) ValidateForSerialization(h *Header) error {
+	validators := []func(*Header) error{
+		v.validateMagicBytes,
+		v.validateVersion,
+		v.validateOriginalSize,
+		v.validateSalt,
+		v.validateIntegrityHash,
+		v.validateAuthTag,
+	}
+
+	for _, validator := range validators {
+		if err := validator(h); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ValidateAfterDeserialization validates header fields after deserialization
+func (v *Validator) ValidateAfterDeserialization(h *Header) error {
+	validators := []func(*Header) error{
+		v.validateMagicBytes,
+		v.validateVersion,
+		v.validateOriginalSize,
+		v.validateSalt,
+	}
+
+	for _, validator := range validators {
+		if err := validator(h); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (v *Validator) validateMagicBytes(h *Header) error {
+	if !utils.SecureCompare(h.magic[:], []byte(MagicBytes)) {
+		return fmt.Errorf("invalid magic bytes: expected %s, got %s", MagicBytes, string(h.magic[:]))
+	}
+	return nil
+}
+
+func (v *Validator) validateVersion(h *Header) error {
+	if h.version == 0 {
+		return fmt.Errorf("invalid version: cannot be zero")
+	}
+	if h.version > CurrentVersion {
+		return fmt.Errorf("unsupported version: %d (maximum supported: %d)", h.version, CurrentVersion)
+	}
+	return nil
+}
+
+func (v *Validator) validateOriginalSize(h *Header) error {
+	if h.originalSize == 0 {
+		return fmt.Errorf("invalid original size: cannot be zero")
+	}
+	return nil
+}
+
+func (v *Validator) validateSalt(h *Header) error {
+	return v.validateNonZeroField(h.salt[:], "salt")
+}
+
+func (v *Validator) validateIntegrityHash(h *Header) error {
+	return v.validateNonZeroField(h.integrityHash[:], "integrity hash")
+}
+
+func (v *Validator) validateAuthTag(h *Header) error {
+	return v.validateNonZeroField(h.authTag[:], "auth tag")
+}
+
+func (v *Validator) validateNonZeroField(field []byte, fieldName string) error {
+	zeroField := make([]byte, len(field))
+	if utils.SecureCompare(field, zeroField) {
+		return fmt.Errorf("%s cannot be all zeros", fieldName)
+	}
+	return nil
+}

--- a/internal/header/verifier.go
+++ b/internal/header/verifier.go
@@ -1,22 +1,27 @@
+// Package header provides functionality for creating, reading, and writing file headers.
 package header
 
 import (
 	"fmt"
 )
 
-// Verifier coordinates all header verification operations
+// Verifier orchestrates the entire header verification process.
+// It aggregates multiple specialized verifiers to perform a comprehensive check
+// of the header's format, integrity, authenticity, and security properties.
 type Verifier struct {
-	key []byte
+	key []byte // The secret key used for cryptographic verification (checksum, integrity, auth).
 }
 
-// NewVerifier creates a new Verifier
+// NewVerifier creates a new Verifier instance with the given key.
 func NewVerifier(key []byte) *Verifier {
 	return &Verifier{key: key}
 }
 
-// VerifyAll performs all verification checks on the header
+// VerifyAll performs a full suite of verification checks on the header.
+// It sequences through format, checksum, integrity, authentication, anti-tampering,
+// and security pattern checks, returning an error on the first failure.
 func (v *Verifier) VerifyAll(header *Header) error {
-	// Create individual verifiers
+	// Instantiate all the necessary verifier components.
 	formatVerifier := NewFormatVerifier()
 	checksumVerifier := NewChecksumVerifier(v.key)
 	integrityVerifier := NewIntegrityVerifier(v.key)
@@ -24,7 +29,7 @@ func (v *Verifier) VerifyAll(header *Header) error {
 	tamperVerifier := NewTamperVerifier()
 	patternVerifier := NewPatternVerifier()
 
-	// Run all verifications
+	// Define the sequence of verifications to be performed.
 	verifiers := []struct {
 		name string
 		fn   func(*Header) error
@@ -37,6 +42,7 @@ func (v *Verifier) VerifyAll(header *Header) error {
 		{"security patterns", patternVerifier.Verify},
 	}
 
+	// Execute each verifier in order, wrapping any error with the verifier's name.
 	for _, verifier := range verifiers {
 		if err := verifier.fn(header); err != nil {
 			return fmt.Errorf("%s verification failed: %w", verifier.name, err)

--- a/internal/header/verifier.go
+++ b/internal/header/verifier.go
@@ -1,260 +1,46 @@
-// Package header provides functionality for creating, reading, and writing file headers.
 package header
 
 import (
-	"crypto/hmac"
 	"fmt"
-
-	"github.com/hambosto/sweetbyte/internal/utils"
 )
 
-// Verifier verifies the integrity and authenticity of a header.
+// Verifier coordinates all header verification operations
 type Verifier struct {
 	key []byte
 }
 
-// NewVerifier creates a new Verifier.
+// NewVerifier creates a new Verifier
 func NewVerifier(key []byte) *Verifier {
-	return &Verifier{
-		key: key,
-	}
+	return &Verifier{key: key}
 }
 
-// VerifyAll performs all verification checks on the header.
+// VerifyAll performs all verification checks on the header
 func (v *Verifier) VerifyAll(header *Header) error {
-	// Verify the format of the header.
-	if err := v.VerifyFormat(header); err != nil {
-		return fmt.Errorf("format verification failed: %w", err)
+	// Create individual verifiers
+	formatVerifier := NewFormatVerifier()
+	checksumVerifier := NewChecksumVerifier(v.key)
+	integrityVerifier := NewIntegrityVerifier(v.key)
+	authVerifier := NewAuthVerifier(v.key)
+	tamperVerifier := NewTamperVerifier()
+	patternVerifier := NewPatternVerifier()
+
+	// Run all verifications
+	verifiers := []struct {
+		name string
+		fn   func(*Header) error
+	}{
+		{"format", formatVerifier.Verify},
+		{"checksum", checksumVerifier.Verify},
+		{"integrity", integrityVerifier.Verify},
+		{"authentication", authVerifier.Verify},
+		{"anti-tampering", tamperVerifier.Verify},
+		{"security patterns", patternVerifier.Verify},
 	}
 
-	// Verify the checksum of the header.
-	if err := v.VerifyChecksum(header); err != nil {
-		return fmt.Errorf("checksum verification failed: %w", err)
-	}
-
-	// Verify the integrity of the header.
-	if err := v.VerifyIntegrity(header); err != nil {
-		return fmt.Errorf("integrity verification failed: %w", err)
-	}
-
-	// Verify the authentication of the header.
-	if err := v.VerifyAuthentication(header); err != nil {
-		return fmt.Errorf("authentication verification failed: %w", err)
-	}
-
-	// Verify the anti-tampering measures of the header.
-	if err := v.VerifyAntiTampering(header); err != nil {
-		return fmt.Errorf("anti-tampering verification failed: %w", err)
-	}
-
-	// Verify the security patterns of the header.
-	if err := v.VerifySecurityPatterns(header); err != nil {
-		return fmt.Errorf("security pattern verification failed: %w", err)
-	}
-
-	return nil
-}
-
-// VerifyFormat verifies the format of the header.
-func (v *Verifier) VerifyFormat(h *Header) error {
-	// Verify the magic bytes.
-	if !utils.SecureCompare(h.magic[:], []byte(MagicBytes)) {
-		return fmt.Errorf("invalid magic bytes: expected %s, got %s",
-			MagicBytes, string(h.magic[:]))
-	}
-
-	// Verify the version.
-	if h.version == 0 {
-		return fmt.Errorf("invalid version: cannot be zero")
-	}
-
-	if h.version > CurrentVersion {
-		return fmt.Errorf("unsupported version: %d (maximum supported: %d)", h.version, CurrentVersion)
-	}
-
-	// Verify the original size.
-	if h.originalSize == 0 {
-		return fmt.Errorf("invalid original size: cannot be zero")
-	}
-
-	// Verify the security flags.
-	if !h.HasFlag(FlagEncrypted) {
-		return fmt.Errorf("encryption flag not set - header created without maximum security")
-	}
-
-	if !h.HasFlag(FlagIntegrityV2) {
-		return fmt.Errorf("integrity v2 flag not set - header created without maximum security")
-	}
-
-	if !h.HasFlag(FlagAntiTamper) {
-		return fmt.Errorf("anti-tamper flag not set - header created without maximum security")
-	}
-
-	return nil
-}
-
-// VerifyChecksum verifies the checksum of the header.
-func (v *Verifier) VerifyChecksum(header *Header) error {
-	protector := NewProtector(v.key)
-	expected, err := protector.ComputeChecksum(header)
-	if err != nil {
-		return fmt.Errorf("failed to compute expected checksum: %w", err)
-	}
-
-	if header.checksum != expected {
-		return fmt.Errorf("checksum mismatch: expected %08x, got %08x", expected, header.checksum)
-	}
-
-	return nil
-}
-
-// VerifyIntegrity verifies the integrity of the header.
-func (v *Verifier) VerifyIntegrity(header *Header) error {
-	protector := NewProtector(v.key)
-	expected, err := protector.ComputeIntegrityHash(header)
-	if err != nil {
-		return fmt.Errorf("failed to compute expected integrity hash: %w", err)
-	}
-
-	if !utils.SecureCompare(header.integrityHash[:], expected) {
-		return fmt.Errorf("integrity hash verification failed - tampering detected")
-	}
-
-	return nil
-}
-
-// VerifyAuthentication verifies the authentication of the header.
-func (v *Verifier) VerifyAuthentication(header *Header) error {
-	if len(v.key) == 0 {
-		return fmt.Errorf("key required for authentication verification")
-	}
-
-	protector := NewProtector(v.key)
-	expected, err := protector.ComputeAuthTag(header)
-	if err != nil {
-		return fmt.Errorf("failed to compute expected auth tag: %w", err)
-	}
-
-	if !hmac.Equal(header.authTag[:], expected) {
-		return fmt.Errorf("authentication verification failed - invalid key or tampering detected")
-	}
-
-	return nil
-}
-
-// VerifyAntiTampering verifies the anti-tampering measures of the header.
-func (v *Verifier) VerifyAntiTampering(h *Header) error {
-	// Check for all-zero fields.
-	zeroSalt := make([]byte, SaltSize)
-	if utils.SecureCompare(h.salt[:], zeroSalt) {
-		return fmt.Errorf("invalid salt: all zeros detected - possible tampering")
-	}
-
-	zeroPadding := make([]byte, PaddingSize)
-	if utils.SecureCompare(h.padding[:], zeroPadding) {
-		return fmt.Errorf("invalid padding: all zeros detected - possible tampering")
-	}
-
-	zeroHash := make([]byte, IntegrityHashSize)
-	if utils.SecureCompare(h.integrityHash[:], zeroHash) {
-		return fmt.Errorf("invalid integrity hash: all zeros detected")
-	}
-
-	zeroAuth := make([]byte, AuthTagSize)
-	if utils.SecureCompare(h.authTag[:], zeroAuth) {
-		return fmt.Errorf("invalid auth tag: all zeros detected")
-	}
-
-	return nil
-}
-
-// VerifySecurityPatterns verifies the security patterns of the header.
-func (v *Verifier) VerifySecurityPatterns(h *Header) error {
-	// Check for repeating bytes in the salt and padding.
-	if err := v.checkForRepeatingBytes(h.salt[:], "salt"); err != nil {
-		return err
-	}
-
-	if err := v.checkForRepeatingBytes(h.padding[:], "padding"); err != nil {
-		return err
-	}
-
-	// Validate the entropy of the salt and padding.
-	if err := v.validateEntropy(h.salt[:], "salt", SaltSize/4); err != nil {
-		return err
-	}
-
-	if err := v.validateEntropy(h.padding[:], "padding", PaddingSize/4); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// checkForRepeatingBytes checks for repeating bytes in a byte slice.
-func (v *Verifier) checkForRepeatingBytes(data []byte, fieldName string) error {
-	if len(data) < 4 {
-		return nil
-	}
-
-	// Check if all bytes are the same.
-	first := data[0]
-	allSame := true
-	for _, b := range data {
-		if b != first {
-			allSame = false
-			break
+	for _, verifier := range verifiers {
+		if err := verifier.fn(header); err != nil {
+			return fmt.Errorf("%s verification failed: %w", verifier.name, err)
 		}
-	}
-
-	if allSame {
-		return fmt.Errorf("suspicious %s: all bytes identical (0x%02x) - possible tampering", fieldName, first)
-	}
-
-	// Check for simple patterns.
-	if v.hasSimplePattern(data) {
-		return fmt.Errorf("suspicious %s: sequential pattern detected - possible tampering", fieldName)
-	}
-
-	return nil
-}
-
-// hasSimplePattern checks for simple ascending or descending patterns in a byte slice.
-func (v *Verifier) hasSimplePattern(data []byte) bool {
-	if len(data) < 4 {
-		return false
-	}
-
-	// Check for ascending pattern.
-	ascending := true
-	for i := 1; i < len(data) && i < 8; i++ {
-		if data[i] != data[i-1]+1 {
-			ascending = false
-			break
-		}
-	}
-
-	// Check for descending pattern.
-	descending := true
-	for i := 1; i < len(data) && i < 8; i++ {
-		if data[i] != data[i-1]-1 {
-			descending = false
-			break
-		}
-	}
-
-	return ascending || descending
-}
-
-// validateEntropy validates the entropy of a byte slice.
-func (v *Verifier) validateEntropy(data []byte, fieldName string, minUnique int) error {
-	uniqueBytes := make(map[byte]bool)
-	for _, b := range data {
-		uniqueBytes[b] = true
-	}
-
-	if len(uniqueBytes) < minUnique {
-		return fmt.Errorf("insufficient entropy in %s: only %d unique bytes (minimum: %d) - possible weak generation", fieldName, len(uniqueBytes), minUnique)
 	}
 
 	return nil


### PR DESCRIPTION
Extracted header validation logic into a dedicated `Validator` type, used by `Deserializer` and `Serializer`. Split comprehensive header verification into specialized types: `FormatVerifier`, `ChecksumVerifier`, `IntegrityVerifier`, `AuthVerifier`, `TamperVerifier`, and `PatternVerifier`. The main `Verifier` now orchestrates these specialized verifiers. This improves modularity, testability, and separation of concerns.