### PR TITLE
refactor: remove verbose comments from codebase

### DIFF
--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -1,9 +1,12 @@
+// Package cli provides the entry point for the command-line interface.
 package cli
 
 import (
 	"github.com/hambosto/sweetbyte/internal/cli"
 )
 
+// NewCLI creates a new CLI command runner.
 func NewCLI() *cli.Commands {
+	// It returns a new command runner from the internal cli package.
 	return cli.NewCommands()
 }

--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -1,11 +1,9 @@
-// Package cli provides the command-line interface for the SweetByte application.
 package cli
 
 import (
 	"github.com/hambosto/sweetbyte/internal/cli"
 )
 
-// NewCLI creates a new Commands application instance.
 func NewCLI() *cli.Commands {
 	return cli.NewCommands()
 }

--- a/cmd/interactive/interactive.go
+++ b/cmd/interactive/interactive.go
@@ -1,9 +1,12 @@
+// Package interactive provides the entry point for the interactive mode.
 package interactive
 
 import (
 	"github.com/hambosto/sweetbyte/internal/interactive"
 )
 
+// NewInteractive creates a new interactive mode runner.
 func NewInteractive() *interactive.Interactive {
+	// It returns a new interactive mode runner from the internal interactive package.
 	return interactive.NewInteractive()
 }

--- a/cmd/interactive/interactive.go
+++ b/cmd/interactive/interactive.go
@@ -1,11 +1,9 @@
-// Package interactive provides the interactive mode for the SweetByte application.
 package interactive
 
 import (
 	"github.com/hambosto/sweetbyte/internal/interactive"
 )
 
-// NewInteractive creates a new interactive application instance.
 func NewInteractive() *interactive.Interactive {
 	return interactive.NewInteractive()
 }

--- a/internal/cipher/aes.go
+++ b/internal/cipher/aes.go
@@ -1,4 +1,3 @@
-// Package cipher provides cryptographic cipher implementations.
 package cipher
 
 import (
@@ -11,69 +10,60 @@ import (
 	"github.com/hambosto/sweetbyte/internal/config"
 )
 
-// AESCipher provides AES-GCM encryption and decryption.
-type AESCipher struct {
+type AESCipher interface {
+	Encrypt(plaintext []byte) ([]byte, error)
+	Decrypt(ciphertext []byte) ([]byte, error)
+}
+
+type aesCipher struct {
 	aead cipher.AEAD
 }
 
-// NewAESCipher creates a new AESCipher with the given key.
-func NewAESCipher(key []byte) (*AESCipher, error) {
-	// The key must be the correct size for AES-256.
+func NewAESCipher(key []byte) (AESCipher, error) {
 	if len(key) != config.EncryptionKeySize {
 		return nil, fmt.Errorf("key must be %d bytes, got %d", config.EncryptionKeySize, len(key))
 	}
 
-	// Create a new AES cipher block.
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cipher: %w", err)
 	}
 
-	// Create a new GCM AEAD.
 	aead, err := cipher.NewGCM(block)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create AES-GCM cipher: %w", err)
 	}
 
-	return &AESCipher{aead: aead}, nil
+	return &aesCipher{aead: aead}, nil
 }
 
-// Encrypt encrypts the given plaintext.
-func (c *AESCipher) Encrypt(plaintext []byte) ([]byte, error) {
-	// Plaintext cannot be empty.
+func (c *aesCipher) Encrypt(plaintext []byte) ([]byte, error) {
 	if len(plaintext) == 0 {
 		return nil, fmt.Errorf("plaintext cannot be empty")
 	}
 
-	// Generate a random nonce.
 	nonce := make([]byte, c.aead.NonceSize())
 	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
 		return nil, fmt.Errorf("failed to generate nonce: %w", err)
 	}
 
-	// Encrypt the plaintext and prepend the nonce.
 	ciphertext := c.aead.Seal(nonce, nonce, plaintext, nil)
 	return ciphertext, nil
 }
 
-// Decrypt decrypts the given ciphertext.
-func (c *AESCipher) Decrypt(ciphertext []byte) ([]byte, error) {
-	// Ciphertext cannot be empty.
+func (c *aesCipher) Decrypt(ciphertext []byte) ([]byte, error) {
 	if len(ciphertext) == 0 {
 		return nil, fmt.Errorf("ciphertext cannot be empty")
 	}
 
-	// The ciphertext must be at least the size of the nonce.
 	nonceSize := c.aead.NonceSize()
 	if len(ciphertext) < nonceSize {
 		return nil, fmt.Errorf("ciphertext too short, need at least %d bytes, got %d", nonceSize, len(ciphertext))
 	}
 
-	// Extract the nonce and the actual ciphertext.
 	nonce := ciphertext[:nonceSize]
 	ciphertext = ciphertext[nonceSize:]
 
-	// Decrypt the ciphertext.
 	plaintext, err := c.aead.Open(nil, nonce, ciphertext, nil)
 	if err != nil {
 		return nil, fmt.Errorf("authentication failed: %w", err)

--- a/internal/cipher/aes.go
+++ b/internal/cipher/aes.go
@@ -1,3 +1,4 @@
+// Package cipher provides cryptographic operations for encryption and decryption.
 package cipher
 
 import (
@@ -10,25 +11,34 @@ import (
 	"github.com/hambosto/sweetbyte/internal/config"
 )
 
+// AESCipher defines the interface for AES encryption and decryption.
 type AESCipher interface {
+	// Encrypt encrypts plaintext using AES-GCM.
 	Encrypt(plaintext []byte) ([]byte, error)
+	// Decrypt decrypts ciphertext using AES-GCM.
 	Decrypt(ciphertext []byte) ([]byte, error)
 }
 
+// aesCipher implements the AESCipher interface using AES-GCM.
 type aesCipher struct {
 	aead cipher.AEAD
 }
 
+// NewAESCipher creates a new AESCipher with the given key.
+// It initializes an AES-GCM cipher with a key of a specific size.
 func NewAESCipher(key []byte) (AESCipher, error) {
+	// Ensure the key has the required size.
 	if len(key) != config.EncryptionKeySize {
 		return nil, fmt.Errorf("key must be %d bytes, got %d", config.EncryptionKeySize, len(key))
 	}
 
+	// Create a new AES cipher block.
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cipher: %w", err)
 	}
 
+	// Create a new GCM AEAD cipher.
 	aead, err := cipher.NewGCM(block)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create AES-GCM cipher: %w", err)
@@ -37,25 +47,34 @@ func NewAESCipher(key []byte) (AESCipher, error) {
 	return &aesCipher{aead: aead}, nil
 }
 
+// Encrypt encrypts the given plaintext.
+// It generates a random nonce, and then seals the plaintext to produce the ciphertext.
 func (c *aesCipher) Encrypt(plaintext []byte) ([]byte, error) {
+	// Ensure plaintext is not empty.
 	if len(plaintext) == 0 {
 		return nil, fmt.Errorf("plaintext cannot be empty")
 	}
 
+	// Generate a random nonce. The nonce is stored at the beginning of the ciphertext.
 	nonce := make([]byte, c.aead.NonceSize())
 	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
 		return nil, fmt.Errorf("failed to generate nonce: %w", err)
 	}
 
+	// Encrypt the plaintext and prepend the nonce.
 	ciphertext := c.aead.Seal(nonce, nonce, plaintext, nil)
 	return ciphertext, nil
 }
 
+// Decrypt decrypts the given ciphertext.
+// It extracts the nonce from the beginning of the ciphertext and then opens it to get the plaintext.
 func (c *aesCipher) Decrypt(ciphertext []byte) ([]byte, error) {
+	// Ensure ciphertext is not empty.
 	if len(ciphertext) == 0 {
 		return nil, fmt.Errorf("ciphertext cannot be empty")
 	}
 
+	// Extract the nonce from the ciphertext.
 	nonceSize := c.aead.NonceSize()
 	if len(ciphertext) < nonceSize {
 		return nil, fmt.Errorf("ciphertext too short, need at least %d bytes, got %d", nonceSize, len(ciphertext))
@@ -64,6 +83,7 @@ func (c *aesCipher) Decrypt(ciphertext []byte) ([]byte, error) {
 	nonce := ciphertext[:nonceSize]
 	ciphertext = ciphertext[nonceSize:]
 
+	// Decrypt the ciphertext.
 	plaintext, err := c.aead.Open(nil, nonce, ciphertext, nil)
 	if err != nil {
 		return nil, fmt.Errorf("authentication failed: %w", err)

--- a/internal/cipher/chacha20poly1305.go
+++ b/internal/cipher/chacha20poly1305.go
@@ -1,4 +1,3 @@
-// Package cipher provides cryptographic cipher implementations.
 package cipher
 
 import (
@@ -11,64 +10,55 @@ import (
 	"golang.org/x/crypto/chacha20poly1305"
 )
 
-// XChaCha20Cipher provides XChaCha20-Poly1305 encryption and decryption.
-type XChaCha20Cipher struct {
+type ChaCha20Cipher interface {
+	Encrypt(plaintext []byte) ([]byte, error)
+	Decrypt(ciphertext []byte) ([]byte, error)
+}
+
+type chaCha20Cipher struct {
 	aead cipher.AEAD
 }
 
-// NewXChaCha20Cipher creates a new XChaCha20Cipher with the given key.
-func NewXChaCha20Cipher(key []byte) (*XChaCha20Cipher, error) {
-	// The key must be the correct size for XChaCha20-Poly1305.
+func NewChaCha20Cipher(key []byte) (ChaCha20Cipher, error) {
 	if len(key) != config.EncryptionKeySize {
 		return nil, fmt.Errorf("key must be %d bytes, got %d", config.EncryptionKeySize, len(key))
 	}
 
-	// Create a new XChaCha20-Poly1305 AEAD.
 	aead, err := chacha20poly1305.NewX(key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create XChaCha20-Poly1305 cipher: %w", err)
 	}
 
-	return &XChaCha20Cipher{aead: aead}, nil
+	return &chaCha20Cipher{aead: aead}, nil
 }
 
-// Encrypt encrypts the given plaintext.
-func (c *XChaCha20Cipher) Encrypt(plaintext []byte) ([]byte, error) {
-	// Plaintext cannot be empty.
+func (c *chaCha20Cipher) Encrypt(plaintext []byte) ([]byte, error) {
 	if len(plaintext) == 0 {
 		return nil, fmt.Errorf("plaintext cannot be empty")
 	}
 
-	// Generate a random nonce.
 	nonce := make([]byte, chacha20poly1305.NonceSizeX)
 	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
 		return nil, fmt.Errorf("failed to generate nonce: %w", err)
 	}
 
-	// Encrypt the plaintext and prepend the nonce.
-	// #nosec G407
 	ciphertext := c.aead.Seal(nonce, nonce, plaintext, nil)
 	return ciphertext, nil
 }
 
-// Decrypt decrypts the given ciphertext.
-func (c *XChaCha20Cipher) Decrypt(ciphertext []byte) ([]byte, error) {
-	// Ciphertext cannot be empty.
+func (c *chaCha20Cipher) Decrypt(ciphertext []byte) ([]byte, error) {
 	if len(ciphertext) == 0 {
 		return nil, fmt.Errorf("ciphertext cannot be empty")
 	}
 
-	// The ciphertext must be at least the size of the nonce.
 	nonceSize := chacha20poly1305.NonceSizeX
 	if len(ciphertext) < nonceSize {
 		return nil, fmt.Errorf("ciphertext too short, need at least %d bytes, got %d", nonceSize, len(ciphertext))
 	}
 
-	// Extract the nonce and the actual ciphertext.
 	nonce := ciphertext[:nonceSize]
 	ciphertext = ciphertext[nonceSize:]
 
-	// Decrypt the ciphertext.
 	plaintext, err := c.aead.Open(nil, nonce, ciphertext, nil)
 	if err != nil {
 		return nil, fmt.Errorf("authentication failed: %w", err)

--- a/internal/cipher/chacha20poly1305.go
+++ b/internal/cipher/chacha20poly1305.go
@@ -1,3 +1,4 @@
+// Package cipher provides cryptographic operations for encryption and decryption.
 package cipher
 
 import (
@@ -10,20 +11,28 @@ import (
 	"golang.org/x/crypto/chacha20poly1305"
 )
 
+// ChaCha20Cipher defines the interface for ChaCha20-Poly1305 encryption and decryption.
 type ChaCha20Cipher interface {
+	// Encrypt encrypts plaintext using XChaCha20-Poly1305.
 	Encrypt(plaintext []byte) ([]byte, error)
+	// Decrypt decrypts ciphertext using XChaCha20-Poly1305.
 	Decrypt(ciphertext []byte) ([]byte, error)
 }
 
+// chaCha20Cipher implements the ChaCha20Cipher interface.
 type chaCha20Cipher struct {
 	aead cipher.AEAD
 }
 
+// NewChaCha20Cipher creates a new ChaCha20Cipher with the given key.
+// It initializes an XChaCha20-Poly1305 AEAD cipher.
 func NewChaCha20Cipher(key []byte) (ChaCha20Cipher, error) {
+	// Ensure the key has the required size.
 	if len(key) != config.EncryptionKeySize {
 		return nil, fmt.Errorf("key must be %d bytes, got %d", config.EncryptionKeySize, len(key))
 	}
 
+	// Create a new XChaCha20-Poly1305 AEAD cipher.
 	aead, err := chacha20poly1305.NewX(key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create XChaCha20-Poly1305 cipher: %w", err)
@@ -32,25 +41,34 @@ func NewChaCha20Cipher(key []byte) (ChaCha20Cipher, error) {
 	return &chaCha20Cipher{aead: aead}, nil
 }
 
+// Encrypt encrypts the given plaintext.
+// It generates a random nonce and seals the plaintext to produce the ciphertext.
 func (c *chaCha20Cipher) Encrypt(plaintext []byte) ([]byte, error) {
+	// Ensure plaintext is not empty.
 	if len(plaintext) == 0 {
 		return nil, fmt.Errorf("plaintext cannot be empty")
 	}
 
+	// Generate a random nonce. The nonce is stored at the beginning of the ciphertext.
 	nonce := make([]byte, chacha20poly1305.NonceSizeX)
 	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
 		return nil, fmt.Errorf("failed to generate nonce: %w", err)
 	}
 
+	// Encrypt the plaintext and prepend the nonce.
 	ciphertext := c.aead.Seal(nonce, nonce, plaintext, nil)
 	return ciphertext, nil
 }
 
+// Decrypt decrypts the given ciphertext.
+// It extracts the nonce from the ciphertext and then opens it to get the plaintext.
 func (c *chaCha20Cipher) Decrypt(ciphertext []byte) ([]byte, error) {
+	// Ensure ciphertext is not empty.
 	if len(ciphertext) == 0 {
 		return nil, fmt.Errorf("ciphertext cannot be empty")
 	}
 
+	// Extract the nonce from the ciphertext.
 	nonceSize := chacha20poly1305.NonceSizeX
 	if len(ciphertext) < nonceSize {
 		return nil, fmt.Errorf("ciphertext too short, need at least %d bytes, got %d", nonceSize, len(ciphertext))
@@ -59,6 +77,7 @@ func (c *chaCha20Cipher) Decrypt(ciphertext []byte) ([]byte, error) {
 	nonce := ciphertext[:nonceSize]
 	ciphertext = ciphertext[nonceSize:]
 
+	// Decrypt the ciphertext.
 	plaintext, err := c.aead.Open(nil, nonce, ciphertext, nil)
 	if err != nil {
 		return nil, fmt.Errorf("authentication failed: %w", err)

--- a/internal/cipher/chacha20poly1305.go
+++ b/internal/cipher/chacha20poly1305.go
@@ -56,6 +56,7 @@ func (c *chaCha20Cipher) Encrypt(plaintext []byte) ([]byte, error) {
 	}
 
 	// Encrypt the plaintext and prepend the nonce.
+	// #nosec G407
 	ciphertext := c.aead.Seal(nonce, nonce, plaintext, nil)
 	return ciphertext, nil
 }

--- a/internal/cipher/cipher.go
+++ b/internal/cipher/cipher.go
@@ -1,8 +1,0 @@
-// Package cipher provides cryptographic cipher implementations.
-package cipher
-
-// Cipher defines the interface for cryptographic ciphers.
-type Cipher interface {
-	Encrypt(plaintext []byte) ([]byte, error)
-	Decrypt(ciphertext []byte) ([]byte, error)
-}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,3 +1,4 @@
+// Package cli provides the command-line interface for the application.
 package cli
 
 import (
@@ -10,13 +11,16 @@ import (
 	"github.com/hambosto/sweetbyte/internal/ui"
 )
 
+// CLI handles the application's command-line interface logic.
 type CLI struct {
 	fileManager    files.FileManager
 	fileOperations operations.FileOperations
 	prompt         ui.PromptInput
 }
 
+// NewCLI creates a new CLI instance with its dependencies.
 func NewCLI() *CLI {
+	// Initialize dependencies.
 	fileManager := files.NewFileManager(config.OverwritePasses)
 	fileOperations := operations.NewFileOperations(fileManager)
 	prompt := ui.NewPromptInput(config.PasswordMinLen)
@@ -27,7 +31,9 @@ func NewCLI() *CLI {
 	}
 }
 
+// Encrypt handles the file encryption process.
 func (p *CLI) Encrypt(inputFile, outputFile, password string, deleteSource, secureDelete bool) error {
+	// If no password is provided, prompt the user for one.
 	if len(password) == 0 {
 		var err error
 		password, err = p.prompt.GetEncryptionPassword()
@@ -36,11 +42,13 @@ func (p *CLI) Encrypt(inputFile, outputFile, password string, deleteSource, secu
 		}
 	}
 
+	// Perform the encryption.
 	fmt.Printf("Encrypting: %s -> %s\n", inputFile, outputFile)
 	if err := p.fileOperations.Encrypt(inputFile, outputFile, password); err != nil {
 		return fmt.Errorf("failed to encrypt %s: %w", inputFile, err)
 	}
 
+	// Optionally, delete the source file.
 	fmt.Printf("File encrypted successfully: %s", outputFile)
 	if deleteSource {
 		deleteOption := options.DeleteStandard
@@ -58,7 +66,9 @@ func (p *CLI) Encrypt(inputFile, outputFile, password string, deleteSource, secu
 	return nil
 }
 
+// Decrypt handles the file decryption process.
 func (p *CLI) Decrypt(inputFile, outputFile, password string, deleteSource, secureDelete bool) error {
+	// If no password is provided, prompt the user for one.
 	if len(password) == 0 {
 		var err error
 		password, err = p.prompt.GetDecryptionPassword()
@@ -67,11 +77,13 @@ func (p *CLI) Decrypt(inputFile, outputFile, password string, deleteSource, secu
 		}
 	}
 
+	// Perform the decryption.
 	fmt.Printf("Decrypting: %s -> %s\n", inputFile, outputFile)
 	if err := p.fileOperations.Decrypt(inputFile, outputFile, password); err != nil {
 		return fmt.Errorf("failed to decrypt %s: %w", inputFile, err)
 	}
 
+	// Optionally, delete the source file.
 	fmt.Printf("✓ File decrypted successfully: %s\n", outputFile)
 	if deleteSource {
 		deleteOption := options.DeleteStandard

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,4 +1,3 @@
-// Package cli provides the command-line interface functionality for SweetByte.
 package cli
 
 import (
@@ -11,28 +10,24 @@ import (
 	"github.com/hambosto/sweetbyte/internal/ui"
 )
 
-// CLI handles the command-line interface operations.
 type CLI struct {
-	fileManager    files.FileManager
-	fileOperations operations.FileOperations
-	prompt         ui.PromptInput
+	fileManager	files.FileManager
+	fileOperations	operations.FileOperations
+	prompt		ui.PromptInput
 }
 
-// NewCLI creates a new CLI.
 func NewCLI() *CLI {
 	fileManager := files.NewFileManager(config.OverwritePasses)
 	fileOperations := operations.NewFileOperations(fileManager)
 	prompt := ui.NewPromptInput(config.PasswordMinLen)
 	return &CLI{
-		fileManager:    fileManager,
-		fileOperations: fileOperations,
-		prompt:         prompt,
+		fileManager:	fileManager,
+		fileOperations:	fileOperations,
+		prompt:		prompt,
 	}
 }
 
-// Encrypt encrypts a file using the command-line interface.
 func (p *CLI) Encrypt(inputFile, outputFile, password string, deleteSource, secureDelete bool) error {
-	// If no password is provided, prompt the user for one.
 	if len(password) == 0 {
 		var err error
 		password, err = p.prompt.GetEncryptionPassword()
@@ -41,7 +36,6 @@ func (p *CLI) Encrypt(inputFile, outputFile, password string, deleteSource, secu
 		}
 	}
 
-	// Encrypt the file.
 	fmt.Printf("Encrypting: %s -> %s\n", inputFile, outputFile)
 	if err := p.fileOperations.Encrypt(inputFile, outputFile, password); err != nil {
 		return fmt.Errorf("failed to encrypt %s: %w", inputFile, err)
@@ -49,7 +43,6 @@ func (p *CLI) Encrypt(inputFile, outputFile, password string, deleteSource, secu
 
 	fmt.Printf("File encrypted successfully: %s", outputFile)
 
-	// If requested, delete the source file.
 	if deleteSource {
 		deleteOption := options.DeleteStandard
 		if secureDelete {
@@ -66,9 +59,7 @@ func (p *CLI) Encrypt(inputFile, outputFile, password string, deleteSource, secu
 	return nil
 }
 
-// Decrypt decrypts a file using the command-line interface.
 func (p *CLI) Decrypt(inputFile, outputFile, password string, deleteSource, secureDelete bool) error {
-	// If no password is provided, prompt the user for one.
 	if len(password) == 0 {
 		var err error
 		password, err = p.prompt.GetDecryptionPassword()
@@ -77,14 +68,13 @@ func (p *CLI) Decrypt(inputFile, outputFile, password string, deleteSource, secu
 		}
 	}
 
-	// Decrypt the file.
 	fmt.Printf("Decrypting: %s -> %s\n", inputFile, outputFile)
 	if err := p.fileOperations.Decrypt(inputFile, outputFile, password); err != nil {
 		return fmt.Errorf("failed to decrypt %s: %w", inputFile, err)
 	}
 
 	fmt.Printf("✓ File decrypted successfully: %s\n", outputFile)
-	// If requested, delete the source file.
+
 	if deleteSource {
 		deleteOption := options.DeleteStandard
 		if secureDelete {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -11,9 +11,9 @@ import (
 )
 
 type CLI struct {
-	fileManager	files.FileManager
-	fileOperations	operations.FileOperations
-	prompt		ui.PromptInput
+	fileManager    files.FileManager
+	fileOperations operations.FileOperations
+	prompt         ui.PromptInput
 }
 
 func NewCLI() *CLI {
@@ -21,9 +21,9 @@ func NewCLI() *CLI {
 	fileOperations := operations.NewFileOperations(fileManager)
 	prompt := ui.NewPromptInput(config.PasswordMinLen)
 	return &CLI{
-		fileManager:	fileManager,
-		fileOperations:	fileOperations,
-		prompt:		prompt,
+		fileManager:    fileManager,
+		fileOperations: fileOperations,
+		prompt:         prompt,
 	}
 }
 
@@ -42,7 +42,6 @@ func (p *CLI) Encrypt(inputFile, outputFile, password string, deleteSource, secu
 	}
 
 	fmt.Printf("File encrypted successfully: %s", outputFile)
-
 	if deleteSource {
 		deleteOption := options.DeleteStandard
 		if secureDelete {
@@ -74,7 +73,6 @@ func (p *CLI) Decrypt(inputFile, outputFile, password string, deleteSource, secu
 	}
 
 	fmt.Printf("✓ File decrypted successfully: %s\n", outputFile)
-
 	if deleteSource {
 		deleteOption := options.DeleteStandard
 		if secureDelete {

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -25,14 +25,14 @@ func (c *Commands) Execute() error {
 
 func (c *Commands) setupCommands() {
 	c.rootCmd = &cobra.Command{
-		Use:	"sweetbyte",
-		Short:	"A tool for multi-layered file encryption and error correction.",
+		Use:   "sweetbyte",
+		Short: "A tool for multi-layered file encryption and error correction.",
 		Long: `SweetByte secures your files through a multi-layered process that includes compression,
 dual-layer encryption with AES-256-GCM and XChaCha20-Poly1305, and Reed-Solomon error
 correction codes. This ensures both confidentiality and resilience against data corruption.
 
 SweetByte can be run in a user-friendly interactive mode or via the command line for automation.`,
-		Version:	config.AppVersion,
+		Version: config.AppVersion,
 		Run: func(cmd *cobra.Command, args []string) {
 			interactiveApp := interactive.NewInteractive()
 			interactiveApp.Run()
@@ -46,16 +46,16 @@ SweetByte can be run in a user-friendly interactive mode or via the command line
 
 func (c *Commands) createEncryptCommand() *cobra.Command {
 	var (
-		inputFile	string
-		outputFile	string
-		password	string
-		deleteSource	bool
-		secureDelete	bool
+		inputFile    string
+		outputFile   string
+		password     string
+		deleteSource bool
+		secureDelete bool
 	)
 
 	cmd := &cobra.Command{
-		Use:	"encrypt [flags]",
-		Short:	"Encrypts a file using a multi-layered approach.",
+		Use:   "encrypt [flags]",
+		Short: "Encrypts a file using a multi-layered approach.",
 		Long: `This command secures a file by first compressing it, then encrypting it with two independent
 layers of state-of-the-art ciphers: AES-256-GCM followed by XChaCha20-Poly1305. Finally,
 it applies Reed-Solomon error correction codes to the ciphertext, protecting it from
@@ -83,16 +83,16 @@ corruption. A strong encryption key is derived from your password using Argon2id
 
 func (c *Commands) createDecryptCommand() *cobra.Command {
 	var (
-		inputFile	string
-		outputFile	string
-		password	string
-		deleteSource	bool
-		secureDelete	bool
+		inputFile    string
+		outputFile   string
+		password     string
+		deleteSource bool
+		secureDelete bool
 	)
 
 	cmd := &cobra.Command{
-		Use:	"decrypt [flags]",
-		Short:	"Decrypts a file encrypted by SweetByte.",
+		Use:   "decrypt [flags]",
+		Short: "Decrypts a file encrypted by SweetByte.",
 		Long: `This command reverses the encryption process. It first uses the Reed-Solomon codes to
 verify and correct any data corruption, then decrypts the data through two layers
 (XChaCha20-Poly1305 and AES-256-GCM), and finally decompresses it to restore the original
@@ -120,8 +120,8 @@ file. The correct password is required to derive the necessary decryption key.`,
 
 func (c *Commands) createInteractiveCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:	"interactive",
-		Short:	"Starts a guided session for multi-layered encryption and decryption.",
+		Use:   "interactive",
+		Short: "Starts a guided session for multi-layered encryption and decryption.",
 		Long: `This command launches SweetByte in interactive mode, providing a step-by-step guided
 experience for encrypting and decrypting files using the multi-layered security process.
 This is ideal for users who prefer a more intuitive and user-friendly interface.`,

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -1,4 +1,3 @@
-// Package cli provides the command-line interface functionality for SweetByte.
 package cli
 
 import (
@@ -10,60 +9,53 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Commands represents the command-line interface of the application.
 type Commands struct {
 	rootCmd *cobra.Command
 }
 
-// NewCommands creates a new Commands instance and sets up the commands.
 func NewCommands() *Commands {
 	cli := &Commands{}
 	cli.setupCommands()
 	return cli
 }
 
-// Execute runs the root command of the Commands.
 func (c *Commands) Execute() error {
 	return c.rootCmd.Execute()
 }
 
-// setupCommands sets up the root command and all subcommands.
 func (c *Commands) setupCommands() {
 	c.rootCmd = &cobra.Command{
-		Use:   "sweetbyte",
-		Short: "A tool for multi-layered file encryption and error correction.",
+		Use:	"sweetbyte",
+		Short:	"A tool for multi-layered file encryption and error correction.",
 		Long: `SweetByte secures your files through a multi-layered process that includes compression,
 dual-layer encryption with AES-256-GCM and XChaCha20-Poly1305, and Reed-Solomon error
 correction codes. This ensures both confidentiality and resilience against data corruption.
 
 SweetByte can be run in a user-friendly interactive mode or via the command line for automation.`,
-		Version: config.AppVersion,
+		Version:	config.AppVersion,
 		Run: func(cmd *cobra.Command, args []string) {
-			// If no command is specified, run the interactive mode.
 			interactiveApp := interactive.NewInteractive()
 			interactiveApp.Run()
 		},
 	}
 
-	// Add the encrypt, decrypt, and interactive commands.
 	c.rootCmd.AddCommand(c.createEncryptCommand())
 	c.rootCmd.AddCommand(c.createDecryptCommand())
 	c.rootCmd.AddCommand(c.createInteractiveCommand())
 }
 
-// createEncryptCommand creates the encrypt command.
 func (c *Commands) createEncryptCommand() *cobra.Command {
 	var (
-		inputFile    string
-		outputFile   string
-		password     string
-		deleteSource bool
-		secureDelete bool
+		inputFile	string
+		outputFile	string
+		password	string
+		deleteSource	bool
+		secureDelete	bool
 	)
 
 	cmd := &cobra.Command{
-		Use:   "encrypt [flags]",
-		Short: "Encrypts a file using a multi-layered approach.",
+		Use:	"encrypt [flags]",
+		Short:	"Encrypts a file using a multi-layered approach.",
 		Long: `This command secures a file by first compressing it, then encrypting it with two independent
 layers of state-of-the-art ciphers: AES-256-GCM followed by XChaCha20-Poly1305. Finally,
 it applies Reed-Solomon error correction codes to the ciphertext, protecting it from
@@ -76,14 +68,12 @@ corruption. A strong encryption key is derived from your password using Argon2id
 		},
 	}
 
-	// Add flags for the encrypt command.
 	cmd.Flags().StringVarP(&inputFile, "input", "i", "", "Input file to encrypt (required)")
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Output encrypted file (default: input + .swb)")
 	cmd.Flags().StringVarP(&password, "password", "p", "", "Encryption password (will prompt if not provided)")
 	cmd.Flags().BoolVar(&deleteSource, "delete-source", false, "Delete source file after encryption")
 	cmd.Flags().BoolVar(&secureDelete, "secure-delete", false, "Use secure deletion (slower but unrecoverable)")
 
-	// Mark the input flag as required.
 	if err := cmd.MarkFlagRequired("input"); err != nil {
 		panic(fmt.Sprintf("failed to mark input flag as required: %v", err))
 	}
@@ -91,19 +81,18 @@ corruption. A strong encryption key is derived from your password using Argon2id
 	return cmd
 }
 
-// createDecryptCommand creates the decrypt command.
 func (c *Commands) createDecryptCommand() *cobra.Command {
 	var (
-		inputFile    string
-		outputFile   string
-		password     string
-		deleteSource bool
-		secureDelete bool
+		inputFile	string
+		outputFile	string
+		password	string
+		deleteSource	bool
+		secureDelete	bool
 	)
 
 	cmd := &cobra.Command{
-		Use:   "decrypt [flags]",
-		Short: "Decrypts a file encrypted by SweetByte.",
+		Use:	"decrypt [flags]",
+		Short:	"Decrypts a file encrypted by SweetByte.",
 		Long: `This command reverses the encryption process. It first uses the Reed-Solomon codes to
 verify and correct any data corruption, then decrypts the data through two layers
 (XChaCha20-Poly1305 and AES-256-GCM), and finally decompresses it to restore the original
@@ -116,14 +105,12 @@ file. The correct password is required to derive the necessary decryption key.`,
 		},
 	}
 
-	// Add flags for the decrypt command.
 	cmd.Flags().StringVarP(&inputFile, "input", "i", "", "Input file to decrypt (required)")
 	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Output decrypted file (default: remove .swb extension)")
 	cmd.Flags().StringVarP(&password, "password", "p", "", "Decryption password (will prompt if not provided)")
 	cmd.Flags().BoolVar(&deleteSource, "delete-source", false, "Delete source file after decryption")
 	cmd.Flags().BoolVar(&secureDelete, "secure-delete", false, "Use secure deletion (slower but unrecoverable)")
 
-	// Mark the input flag as required.
 	if err := cmd.MarkFlagRequired("input"); err != nil {
 		panic(fmt.Sprintf("failed to mark input flag as required: %v", err))
 	}
@@ -131,25 +118,21 @@ file. The correct password is required to derive the necessary decryption key.`,
 	return cmd
 }
 
-// createInteractiveCommand creates the interactive command.
 func (c *Commands) createInteractiveCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "interactive",
-		Short: "Starts a guided session for multi-layered encryption and decryption.",
+		Use:	"interactive",
+		Short:	"Starts a guided session for multi-layered encryption and decryption.",
 		Long: `This command launches SweetByte in interactive mode, providing a step-by-step guided
 experience for encrypting and decrypting files using the multi-layered security process.
 This is ideal for users who prefer a more intuitive and user-friendly interface.`,
 		Run: func(cmd *cobra.Command, args []string) {
-			// Run the interactive mode.
 			interactiveApp := interactive.NewInteractive()
 			interactiveApp.Run()
 		},
 	}
 }
 
-// runEncrypt runs the encryption process.
 func (c *Commands) runEncrypt(inputFile, outputFile, password string, deleteSource, secureDelete bool) error {
-	// Check if the input file exists.
 	if _, err := os.Stat(inputFile); err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("input file not found: %s", inputFile)
@@ -157,26 +140,21 @@ func (c *Commands) runEncrypt(inputFile, outputFile, password string, deleteSour
 		return fmt.Errorf("failed to access input file %s: %w", inputFile, err)
 	}
 
-	// If the output file is not specified, create a default name.
 	if len(outputFile) == 0 {
 		outputFile = inputFile + config.FileExtension
 	}
 
-	// Check if the output file already exists.
 	if _, err := os.Stat(outputFile); err == nil {
 		return fmt.Errorf("output file already exists: %s", outputFile)
 	} else if !os.IsNotExist(err) {
 		return fmt.Errorf("failed to access output file %s: %w", outputFile, err)
 	}
 
-	// Create a new Commands processor and run the encryption.
 	processor := NewCLI()
 	return processor.Encrypt(inputFile, outputFile, password, deleteSource, secureDelete)
 }
 
-// runDecrypt runs the decryption process.
 func (c *Commands) runDecrypt(inputFile, outputFile, password string, deleteSource, secureDelete bool) error {
-	// Check if the input file exists.
 	if _, err := os.Stat(inputFile); err != nil {
 		if os.IsNotExist(err) {
 			return fmt.Errorf("input file not found: %s", inputFile)
@@ -184,7 +162,6 @@ func (c *Commands) runDecrypt(inputFile, outputFile, password string, deleteSour
 		return fmt.Errorf("failed to access input file %s: %w", inputFile, err)
 	}
 
-	// If the output file is not specified, create a default name.
 	if len(outputFile) == 0 {
 		if len(inputFile) > len(config.FileExtension) &&
 			inputFile[len(inputFile)-len(config.FileExtension):] == config.FileExtension {
@@ -194,14 +171,12 @@ func (c *Commands) runDecrypt(inputFile, outputFile, password string, deleteSour
 		}
 	}
 
-	// Check if the output file already exists.
 	if _, err := os.Stat(outputFile); err == nil {
 		return fmt.Errorf("output file already exists: %s", outputFile)
 	} else if !os.IsNotExist(err) {
 		return fmt.Errorf("failed to access output file %s: %w", outputFile, err)
 	}
 
-	// Create a new Commands processor and run the decryption.
 	processor := NewCLI()
 	return processor.Decrypt(inputFile, outputFile, password, deleteSource, secureDelete)
 }

--- a/internal/compression/compressor.go
+++ b/internal/compression/compressor.go
@@ -10,12 +10,9 @@ import (
 type Level int
 
 const (
-	LevelNoCompression	Level	= iota
-
+	LevelNoCompression Level = iota
 	LevelBestSpeed
-
 	LevelDefaultCompression
-
 	LevelBestCompression
 )
 

--- a/internal/compression/compressor.go
+++ b/internal/compression/compressor.go
@@ -1,4 +1,3 @@
-// Package compression provides data compression and decompression functionality.
 package compression
 
 import (
@@ -8,36 +7,30 @@ import (
 	"io"
 )
 
-// Level defines the level of compression to be used.
 type Level int
 
 const (
-	// LevelNoCompression disables compression.
-	LevelNoCompression Level = iota
-	// LevelBestSpeed provides the fastest compression.
+	LevelNoCompression	Level	= iota
+
 	LevelBestSpeed
-	// LevelDefaultCompression provides the default compression level.
+
 	LevelDefaultCompression
-	// LevelBestCompression provides the best compression.
+
 	LevelBestCompression
 )
 
-// Compressor defines the interface for data compression and decompression.
 type Compressor interface {
 	Compress(data []byte) ([]byte, error)
 	Decompress(data []byte) ([]byte, error)
 }
 
-// compressor handles data compression and decompression using zlib.
 type compressor struct {
 	level int
 }
 
-// NewCompressor creates a new Compressor with the specified compression level.
 func NewCompressor(level Level) (Compressor, error) {
 	var zlibLevel int
 
-	// Map the custom compression level to the zlib compression level.
 	switch level {
 	case LevelNoCompression:
 		zlibLevel = zlib.NoCompression
@@ -54,26 +47,21 @@ func NewCompressor(level Level) (Compressor, error) {
 	return &compressor{level: zlibLevel}, nil
 }
 
-// Compress compresses the given data.
 func (c *compressor) Compress(data []byte) ([]byte, error) {
-	// Data cannot be empty.
 	if len(data) == 0 {
 		return nil, fmt.Errorf("data cannot be empty")
 	}
 
-	// Create a new buffer and a zlib writer.
 	var buf bytes.Buffer
 	writer, err := zlib.NewWriterLevel(&buf, c.level)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create compressor: %w", err)
 	}
 
-	// Write the data to the writer.
 	if _, err := writer.Write(data); err != nil {
 		return nil, fmt.Errorf("failed to compress data: %w", err)
 	}
 
-	// Close the writer to finalize compression.
 	if err := writer.Close(); err != nil {
 		return nil, fmt.Errorf("failed to finalize compression: %w", err)
 	}
@@ -81,26 +69,21 @@ func (c *compressor) Compress(data []byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-// Decompress decompress the given data.
 func (c *compressor) Decompress(data []byte) ([]byte, error) {
-	// Data cannot be empty.
 	if len(data) == 0 {
 		return nil, fmt.Errorf("data cannot be empty")
 	}
 
-	// Create a new zlib reader.
 	reader, err := zlib.NewReader(bytes.NewReader(data))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create decompressor: %w", err)
 	}
 
-	// Copy the decompressed data to a buffer.
 	var buf bytes.Buffer
 	if _, err := io.Copy(&buf, io.LimitReader(reader, 10<<20)); err != nil {
 		return nil, fmt.Errorf("failed to decompress data: %w", err)
 	}
 
-	// Close the reader to finalize decompression.
 	if err := reader.Close(); err != nil {
 		return nil, fmt.Errorf("failed to finalize decompression: %w", err)
 	}

--- a/internal/compression/compressor.go
+++ b/internal/compression/compressor.go
@@ -1,3 +1,4 @@
+// Package compression provides zlib compression and decompression functionalities.
 package compression
 
 import (
@@ -7,27 +8,38 @@ import (
 	"io"
 )
 
+// Level defines the compression level.
 type Level int
 
 const (
+	// LevelNoCompression provides no compression.
 	LevelNoCompression Level = iota
+	// LevelBestSpeed provides the fastest compression.
 	LevelBestSpeed
+	// LevelDefaultCompression provides the default compression level.
 	LevelDefaultCompression
+	// LevelBestCompression provides the best compression.
 	LevelBestCompression
 )
 
+// Compressor defines the interface for compression and decompression.
 type Compressor interface {
+	// Compress compresses the given data.
 	Compress(data []byte) ([]byte, error)
+	// Decompress decompress a given data.
 	Decompress(data []byte) ([]byte, error)
 }
 
+// compressor implements the Compressor interface using zlib.
 type compressor struct {
 	level int
 }
 
+// NewCompressor creates a new Compressor with the given compression level.
 func NewCompressor(level Level) (Compressor, error) {
 	var zlibLevel int
 
+	// Map the custom compression level to the zlib compression level.
 	switch level {
 	case LevelNoCompression:
 		zlibLevel = zlib.NoCompression
@@ -44,21 +56,26 @@ func NewCompressor(level Level) (Compressor, error) {
 	return &compressor{level: zlibLevel}, nil
 }
 
+// Compress compresses the given data using the configured zlib compression level.
 func (c *compressor) Compress(data []byte) ([]byte, error) {
+	// Ensure data is not empty.
 	if len(data) == 0 {
 		return nil, fmt.Errorf("data cannot be empty")
 	}
 
+	// Create a new zlib writer.
 	var buf bytes.Buffer
 	writer, err := zlib.NewWriterLevel(&buf, c.level)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create compressor: %w", err)
 	}
 
+	// Write data to the writer to compress it.
 	if _, err := writer.Write(data); err != nil {
 		return nil, fmt.Errorf("failed to compress data: %w", err)
 	}
 
+	// Close the writer to finalize the compression.
 	if err := writer.Close(); err != nil {
 		return nil, fmt.Errorf("failed to finalize compression: %w", err)
 	}
@@ -66,21 +83,26 @@ func (c *compressor) Compress(data []byte) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// Decompress decompresses the given data.
 func (c *compressor) Decompress(data []byte) ([]byte, error) {
+	// Ensure data is not empty.
 	if len(data) == 0 {
 		return nil, fmt.Errorf("data cannot be empty")
 	}
 
+	// Create a new zlib reader.
 	reader, err := zlib.NewReader(bytes.NewReader(data))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create decompressor: %w", err)
 	}
 
+	// Read the decompressed data from the reader.
 	var buf bytes.Buffer
 	if _, err := io.Copy(&buf, io.LimitReader(reader, 10<<20)); err != nil {
 		return nil, fmt.Errorf("failed to decompress data: %w", err)
 	}
 
+	// Close the reader.
 	if err := reader.Close(); err != nil {
 		return nil, fmt.Errorf("failed to finalize decompression: %w", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,72 +1,41 @@
-// Package config provides configuration constants for the SweetByte application.
 package config
 
 const (
-	// AppName is the name of the application.
-	AppName = "SweetByte"
-
-	// AppVersion is the current version of the application.
-	AppVersion = "1.0"
-
-	// FileExtension is the file extension applied to encrypted files.
-	FileExtension = ".swb"
+	AppName		= "SweetByte"
+	AppVersion	= "1.0"
+	FileExtension	= ".swb"
 )
 
 const (
-	// DefaultChunkSize is the default size (in bytes) of chunks used
-	// during streaming read/write operations (e.g., encryption, decryption).
-	DefaultChunkSize = 1 * 1024 * 1024 // 1 MB
-
-	// OverwritePasses is the number of overwrite passes used when securely
-	// deleting files to reduce the chance of data recovery.
-	OverwritePasses = 3
-
-	// PasswordMinLen defines the minimum required length for user passwords.
-	PasswordMinLen = 8
+	DefaultChunkSize	= 1 * 1024 * 1024	// 1 MB
+	OverwritePasses		= 3
+	PasswordMinLen		= 8
 )
 
 const (
-	// SaltSize is the number of random bytes used as a salt in key derivation.
-	SaltSize = 32
-
-	// MasterKeySize is the size (in bytes) of the master key derived from the password.
-	MasterKeySize = 64
-
-	// EncryptionKeySize is the size (in bytes) of the encryption key used for symmetric encryption.
-	EncryptionKeySize = 32
+	SaltSize		= 32
+	MasterKeySize		= 64
+	EncryptionKeySize	= 32
 )
 
 var (
-	// ExcludedDirs lists directories that should be skipped when scanning
-	// for files to encrypt or process. These are typically system, cache,
-	// or development-related directories.
-	ExcludedDirs = []string{
+	ExcludedDirs	= []string{
 		"vendor/", "node_modules/", ".git", ".github",
 		".vscode/", "build/", "dist/", "target/",
 		".config", ".local", ".cache", ".ssh",
 	}
 
-	// ExcludedExts lists file extensions that should be skipped when scanning
-	// for files to encrypt. This avoids encrypting executables, system files,
-	// or project configuration files.
-	ExcludedExts = []string{
+	ExcludedExts	= []string{
 		".go", "go.mod", "go.sum", ".nix", ".gitignore",
 		".exe", ".dll", ".so", ".dylib",
 	}
 )
 
 const (
-	// DataShards is the number of data shards used in Reed-Solomon
-	// erasure coding for redundancy and reliability.
-	DataShards = 4
-
-	// ParityShards is the number of parity shards used in Reed-Solomon
-	// erasure coding to allow data recovery in case of corruption or loss.
-	ParityShards = 10
+	DataShards	= 4
+	ParityShards	= 10
 )
 
 const (
-	// PaddingSize is the fixed number of padding bytes applied to the file
-	// header to ensure alignment and obscure actual header size.
 	PaddingSize = 16
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,30 +1,42 @@
+// Package config provides configuration constants for the application.
 package config
 
 const (
-	AppName       = "SweetByte"
-	AppVersion    = "1.0"
+	// AppName is the name of the application.
+	AppName = "SweetByte"
+	// AppVersion is the version of the application.
+	AppVersion = "1.0"
+	// FileExtension is the file extension for encrypted files.
 	FileExtension = ".swb"
 )
 
 const (
+	// DefaultChunkSize is the default size of chunks for streaming processing.
 	DefaultChunkSize = 1 * 1024 * 1024 // 1 MB
-	OverwritePasses  = 3
-	PasswordMinLen   = 8
+	// OverwritePasses is the number of passes for secure file deletion.
+	OverwritePasses = 3
+	// PasswordMinLen is the minimum length of a password.
+	PasswordMinLen = 8
 )
 
 const (
-	SaltSize          = 32
-	MasterKeySize     = 64
+	// SaltSize is the size of the salt used for key derivation.
+	SaltSize = 32
+	// MasterKeySize is the size of the master key.
+	MasterKeySize = 64
+	// EncryptionKeySize is the size of the encryption key.
 	EncryptionKeySize = 32
 )
 
 var (
+	// ExcludedDirs is a list of directories to exclude when searching for files.
 	ExcludedDirs = []string{
 		"vendor/", "node_modules/", ".git", ".github",
 		".vscode/", "build/", "dist/", "target/",
 		".config", ".local", ".cache", ".ssh",
 	}
 
+	// ExcludedExts is a list of file extensions to exclude when searching for files.
 	ExcludedExts = []string{
 		".go", "go.mod", "go.sum", ".nix", ".gitignore",
 		".exe", ".dll", ".so", ".dylib",
@@ -32,10 +44,13 @@ var (
 )
 
 const (
-	DataShards   = 4
+	// DataShards is the number of data shards for Reed-Solomon encoding.
+	DataShards = 4
+	// ParityShards is the number of parity shards for Reed-Solomon encoding.
 	ParityShards = 10
 )
 
 const (
+	// PaddingSize is the block size for PKCS#7 padding.
 	PaddingSize = 16
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,39 +1,39 @@
 package config
 
 const (
-	AppName		= "SweetByte"
-	AppVersion	= "1.0"
-	FileExtension	= ".swb"
+	AppName       = "SweetByte"
+	AppVersion    = "1.0"
+	FileExtension = ".swb"
 )
 
 const (
-	DefaultChunkSize	= 1 * 1024 * 1024	// 1 MB
-	OverwritePasses		= 3
-	PasswordMinLen		= 8
+	DefaultChunkSize = 1 * 1024 * 1024 // 1 MB
+	OverwritePasses  = 3
+	PasswordMinLen   = 8
 )
 
 const (
-	SaltSize		= 32
-	MasterKeySize		= 64
-	EncryptionKeySize	= 32
+	SaltSize          = 32
+	MasterKeySize     = 64
+	EncryptionKeySize = 32
 )
 
 var (
-	ExcludedDirs	= []string{
+	ExcludedDirs = []string{
 		"vendor/", "node_modules/", ".git", ".github",
 		".vscode/", "build/", "dist/", "target/",
 		".config", ".local", ".cache", ".ssh",
 	}
 
-	ExcludedExts	= []string{
+	ExcludedExts = []string{
 		".go", "go.mod", "go.sum", ".nix", ".gitignore",
 		".exe", ".dll", ".so", ".dylib",
 	}
 )
 
 const (
-	DataShards	= 4
-	ParityShards	= 10
+	DataShards   = 4
+	ParityShards = 10
 )
 
 const (

--- a/internal/encoding/encoder.go
+++ b/internal/encoding/encoder.go
@@ -1,4 +1,3 @@
-// Package encoding provides data encoding and decoding functionality using Reed-Solomon codes.
 package encoding
 
 import (
@@ -8,27 +7,22 @@ import (
 )
 
 const (
-	// MaxDataLen is the maximum length of data that can be encoded.
 	MaxDataLen = 1 << 30
 )
 
-// Encoder defines the interface for data encoding and decoding.
 type Encoder interface {
 	Encode(data []byte) ([]byte, error)
 	Decode(encoded []byte) ([]byte, error)
 }
 
-// reedSolomonEncoder handles Reed-Solomon encoding and decoding.
 type encoder struct {
-	dataShards   int
-	parityShards int
-	encoder      reedsolomon.Encoder
-	shards       Shards
+	dataShards	int
+	parityShards	int
+	encoder		reedsolomon.Encoder
+	shards		Shards
 }
 
-// NewEncoder creates a new Encoder with the specified number of data and parity shards.
 func NewEncoder(dataShards, parityShards int) (Encoder, error) {
-	// Validate the number of shards.
 	if dataShards <= 0 {
 		return nil, fmt.Errorf("data shards must be positive")
 	}
@@ -39,23 +33,20 @@ func NewEncoder(dataShards, parityShards int) (Encoder, error) {
 		return nil, fmt.Errorf("total shards cannot exceed 255")
 	}
 
-	// Create a new Reed-Solomon encoder.
 	enc, err := reedsolomon.New(dataShards, parityShards)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create reed-solomon encoder: %w", err)
 	}
 
 	return &encoder{
-		dataShards:   dataShards,
-		parityShards: parityShards,
-		encoder:      enc,
-		shards:       NewShards(dataShards, parityShards),
+		dataShards:	dataShards,
+		parityShards:	parityShards,
+		encoder:	enc,
+		shards:		NewShards(dataShards, parityShards),
 	}, nil
 }
 
-// Encode encodes the given data using Reed-Solomon codes.
 func (e *encoder) Encode(data []byte) ([]byte, error) {
-	// Validate the data length.
 	if len(data) == 0 {
 		return nil, fmt.Errorf("input data cannot be empty")
 	}
@@ -63,22 +54,18 @@ func (e *encoder) Encode(data []byte) ([]byte, error) {
 		return nil, fmt.Errorf("data size %d exceeds maximum %d bytes", len(data), MaxDataLen)
 	}
 
-	// Split the data into shards.
 	shards := e.shards.Split(data)
-	// Encode the shards.
+
 	if err := e.encoder.Encode(shards); err != nil {
 		return nil, fmt.Errorf("encoding failed: %w", err)
 	}
 
-	// Combine the shards into a single byte slice.
 	return e.shards.Combine(shards), nil
 }
 
-// Decode decodes the given encoded data.
 func (e *encoder) Decode(encoded []byte) ([]byte, error) {
 	totalShards := e.dataShards + e.parityShards
 
-	// Validate the encoded data length.
 	if len(encoded) == 0 {
 		return nil, fmt.Errorf("encoded data cannot be empty")
 	}
@@ -86,14 +73,11 @@ func (e *encoder) Decode(encoded []byte) ([]byte, error) {
 		return nil, fmt.Errorf("encoded data length %d not divisible by total shards %d", len(encoded), totalShards)
 	}
 
-	// Split the encoded data into shards.
 	shards := e.shards.SplitEncoded(encoded)
-	// Reconstruct the shards.
 	if err := e.encoder.Reconstruct(shards); err != nil {
 		return nil, fmt.Errorf("reconstruction failed: %w", err)
 	}
 
-	// Extract the original data from the shards.
 	data, err := e.shards.Extract(shards)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract data from shards: %w", err)

--- a/internal/encoding/encoder.go
+++ b/internal/encoding/encoder.go
@@ -16,10 +16,10 @@ type Encoder interface {
 }
 
 type encoder struct {
-	dataShards	int
-	parityShards	int
-	encoder		reedsolomon.Encoder
-	shards		Shards
+	dataShards   int
+	parityShards int
+	encoder      reedsolomon.Encoder
+	shards       Shards
 }
 
 func NewEncoder(dataShards, parityShards int) (Encoder, error) {
@@ -39,10 +39,10 @@ func NewEncoder(dataShards, parityShards int) (Encoder, error) {
 	}
 
 	return &encoder{
-		dataShards:	dataShards,
-		parityShards:	parityShards,
-		encoder:	enc,
-		shards:		NewShards(dataShards, parityShards),
+		dataShards:   dataShards,
+		parityShards: parityShards,
+		encoder:      enc,
+		shards:       NewShards(dataShards, parityShards),
 	}, nil
 }
 
@@ -55,7 +55,6 @@ func (e *encoder) Encode(data []byte) ([]byte, error) {
 	}
 
 	shards := e.shards.Split(data)
-
 	if err := e.encoder.Encode(shards); err != nil {
 		return nil, fmt.Errorf("encoding failed: %w", err)
 	}
@@ -65,7 +64,6 @@ func (e *encoder) Encode(data []byte) ([]byte, error) {
 
 func (e *encoder) Decode(encoded []byte) ([]byte, error) {
 	totalShards := e.dataShards + e.parityShards
-
 	if len(encoded) == 0 {
 		return nil, fmt.Errorf("encoded data cannot be empty")
 	}

--- a/internal/encoding/encoder.go
+++ b/internal/encoding/encoder.go
@@ -1,3 +1,4 @@
+// Package encoding provides Reed-Solomon encoding and decoding functionalities.
 package encoding
 
 import (
@@ -7,14 +8,19 @@ import (
 )
 
 const (
+	// MaxDataLen is the maximum data length that can be encoded.
 	MaxDataLen = 1 << 30
 )
 
+// Encoder defines the interface for Reed-Solomon encoding and decoding.
 type Encoder interface {
+	// Encode encodes the given data using Reed-Solomon.
 	Encode(data []byte) ([]byte, error)
+	// Decode decodes the given data using Reed-Solomon.
 	Decode(encoded []byte) ([]byte, error)
 }
 
+// encoder implements the Encoder interface.
 type encoder struct {
 	dataShards   int
 	parityShards int
@@ -22,7 +28,9 @@ type encoder struct {
 	shards       Shards
 }
 
+// NewEncoder creates a new Encoder with the given number of data and parity shards.
 func NewEncoder(dataShards, parityShards int) (Encoder, error) {
+	// Validate the number of shards.
 	if dataShards <= 0 {
 		return nil, fmt.Errorf("data shards must be positive")
 	}
@@ -33,6 +41,7 @@ func NewEncoder(dataShards, parityShards int) (Encoder, error) {
 		return nil, fmt.Errorf("total shards cannot exceed 255")
 	}
 
+	// Create a new Reed-Solomon encoder.
 	enc, err := reedsolomon.New(dataShards, parityShards)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create reed-solomon encoder: %w", err)
@@ -46,7 +55,9 @@ func NewEncoder(dataShards, parityShards int) (Encoder, error) {
 	}, nil
 }
 
+// Encode encodes the given data using Reed-Solomon.
 func (e *encoder) Encode(data []byte) ([]byte, error) {
+	// Validate the data length.
 	if len(data) == 0 {
 		return nil, fmt.Errorf("input data cannot be empty")
 	}
@@ -54,16 +65,21 @@ func (e *encoder) Encode(data []byte) ([]byte, error) {
 		return nil, fmt.Errorf("data size %d exceeds maximum %d bytes", len(data), MaxDataLen)
 	}
 
+	// Split the data into shards.
 	shards := e.shards.Split(data)
+	// Encode the shards.
 	if err := e.encoder.Encode(shards); err != nil {
 		return nil, fmt.Errorf("encoding failed: %w", err)
 	}
 
+	// Combine the shards into a single byte slice.
 	return e.shards.Combine(shards), nil
 }
 
+// Decode decodes the given data using Reed-Solomon.
 func (e *encoder) Decode(encoded []byte) ([]byte, error) {
 	totalShards := e.dataShards + e.parityShards
+	// Validate the encoded data length.
 	if len(encoded) == 0 {
 		return nil, fmt.Errorf("encoded data cannot be empty")
 	}
@@ -71,11 +87,14 @@ func (e *encoder) Decode(encoded []byte) ([]byte, error) {
 		return nil, fmt.Errorf("encoded data length %d not divisible by total shards %d", len(encoded), totalShards)
 	}
 
+	// Split the encoded data into shards.
 	shards := e.shards.SplitEncoded(encoded)
+	// Reconstruct the data from the shards.
 	if err := e.encoder.Reconstruct(shards); err != nil {
 		return nil, fmt.Errorf("reconstruction failed: %w", err)
 	}
 
+	// Extract the original data from the shards.
 	data, err := e.shards.Extract(shards)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract data from shards: %w", err)

--- a/internal/encoding/shards.go
+++ b/internal/encoding/shards.go
@@ -1,22 +1,30 @@
+// Package encoding provides Reed-Solomon encoding and decoding functionalities.
 package encoding
 
 import (
 	"fmt"
 )
 
+// Shards defines the interface for splitting and combining data shards.
 type Shards interface {
+	// Split splits the given data into data and parity shards.
 	Split(data []byte) [][]byte
+	// SplitEncoded splits the encoded data into shards.
 	SplitEncoded(data []byte) [][]byte
+	// Combine combines the shards into a single byte slice.
 	Combine(shards [][]byte) []byte
+	// Extract extracts the original data from the data shards.
 	Extract(shards [][]byte) ([]byte, error)
 }
 
+// shards implements the Shards interface.
 type shards struct {
 	dataShards   int
 	parityShards int
 	totalShards  int
 }
 
+// NewShards creates a new Shards instance.
 func NewShards(dataShards, parityShards int) *shards {
 	return &shards{
 		dataShards:   dataShards,
@@ -25,13 +33,17 @@ func NewShards(dataShards, parityShards int) *shards {
 	}
 }
 
+// Split splits the given data into data and parity shards.
 func (s *shards) Split(data []byte) [][]byte {
+	// Calculate the size of each shard.
 	shardSize := (len(data) + s.dataShards - 1) / s.dataShards
+	// Create the shards.
 	shards := make([][]byte, s.totalShards)
 	for i := range shards {
 		shards[i] = make([]byte, shardSize)
 	}
 
+	// Distribute the data among the data shards.
 	for i, b := range data {
 		shardIndex := i / shardSize
 		posInShard := i % shardSize
@@ -41,10 +53,14 @@ func (s *shards) Split(data []byte) [][]byte {
 	return shards
 }
 
+// SplitEncoded splits the encoded data into shards.
 func (s *shards) SplitEncoded(data []byte) [][]byte {
+	// Calculate the size of each shard.
 	shardSize := len(data) / s.totalShards
+	// Create the shards.
 	shards := make([][]byte, s.totalShards)
 
+	// Copy the data into the shards.
 	for i := range shards {
 		start := i * shardSize
 		end := (i + 1) * shardSize
@@ -55,14 +71,19 @@ func (s *shards) SplitEncoded(data []byte) [][]byte {
 	return shards
 }
 
+// Combine combines the shards into a single byte slice.
 func (s *shards) Combine(shards [][]byte) []byte {
 	if len(shards) == 0 {
 		return nil
 	}
 
+	// Get the size of each shard.
 	shardSize := len(shards[0])
+	// Calculate the total size of the combined data.
 	totalSize := shardSize * len(shards)
+	// Create a buffer for the combined data.
 	result := make([]byte, totalSize)
+	// Copy the data from each shard into the buffer.
 	for i, shard := range shards {
 		start := i * shardSize
 		copy(result[start:start+shardSize], shard)
@@ -71,13 +92,18 @@ func (s *shards) Combine(shards [][]byte) []byte {
 	return result
 }
 
+// Extract extracts the original data from the data shards.
 func (s *shards) Extract(shards [][]byte) ([]byte, error) {
+	// Ensure there are enough shards to reconstruct the data.
 	if len(shards) < s.dataShards {
 		return nil, fmt.Errorf("insufficient shards, have %d but need at least %d data shards", len(shards), s.dataShards)
 	}
 
+	// Get the size of each shard.
 	shardSize := len(shards[0])
+	// Create a buffer for the combined data.
 	combined := make([]byte, 0, shardSize*s.dataShards)
+	// Append the data from each data shard to the buffer.
 	for i := 0; i < s.dataShards; i++ {
 		combined = append(combined, shards[i]...)
 	}

--- a/internal/encoding/shards.go
+++ b/internal/encoding/shards.go
@@ -1,11 +1,9 @@
-// Package encoding provides data encoding and decoding functionality using Reed-Solomon codes.
 package encoding
 
 import (
 	"fmt"
 )
 
-// Shards defines the interface for data combining and encoding.
 type Shards interface {
 	Split(data []byte) [][]byte
 	SplitEncoded(data []byte) [][]byte
@@ -13,34 +11,27 @@ type Shards interface {
 	Extract(shards [][]byte) ([]byte, error)
 }
 
-// shards handles splitting and combining data shards for Reed-Solomon encoding.
 type shards struct {
-	dataShards   int
-	parityShards int
-	totalShards  int
+	dataShards	int
+	parityShards	int
+	totalShards	int
 }
 
-// NewShards creates a new Shards instance.
 func NewShards(dataShards, parityShards int) *shards {
 	return &shards{
-		dataShards:   dataShards,
-		parityShards: parityShards,
-		totalShards:  dataShards + parityShards,
+		dataShards:	dataShards,
+		parityShards:	parityShards,
+		totalShards:	dataShards + parityShards,
 	}
 }
 
-// Split splits the data into shards.
 func (s *shards) Split(data []byte) [][]byte {
-	// Calculate the size of each shard.
 	shardSize := (len(data) + s.dataShards - 1) / s.dataShards
-
-	// Create the shards.
 	shards := make([][]byte, s.totalShards)
 	for i := range shards {
 		shards[i] = make([]byte, shardSize)
 	}
 
-	// Distribute the data among the shards.
 	for i, b := range data {
 		shardIndex := i / shardSize
 		posInShard := i % shardSize
@@ -50,13 +41,10 @@ func (s *shards) Split(data []byte) [][]byte {
 	return shards
 }
 
-// SplitEncoded splits the encoded data into shards.
 func (s *shards) SplitEncoded(data []byte) [][]byte {
-	// Calculate the size of each shard.
 	shardSize := len(data) / s.totalShards
 	shards := make([][]byte, s.totalShards)
 
-	// Create the shards from the encoded data.
 	for i := range shards {
 		start := i * shardSize
 		end := (i + 1) * shardSize
@@ -67,18 +55,15 @@ func (s *shards) SplitEncoded(data []byte) [][]byte {
 	return shards
 }
 
-// Combine combines the shards into a single byte slice.
 func (s *shards) Combine(shards [][]byte) []byte {
 	if len(shards) == 0 {
 		return nil
 	}
 
-	// Calculate the total size of the combined data.
 	shardSize := len(shards[0])
 	totalSize := shardSize * len(shards)
 	result := make([]byte, totalSize)
 
-	// Copy the data from each shard into the result.
 	for i, shard := range shards {
 		start := i * shardSize
 		copy(result[start:start+shardSize], shard)
@@ -87,14 +72,11 @@ func (s *shards) Combine(shards [][]byte) []byte {
 	return result
 }
 
-// Extract extracts the original data from the shards.
 func (s *shards) Extract(shards [][]byte) ([]byte, error) {
-	// Check if there are enough shards to reconstruct the data.
 	if len(shards) < s.dataShards {
 		return nil, fmt.Errorf("insufficient shards, have %d but need at least %d data shards", len(shards), s.dataShards)
 	}
 
-	// Combine the data shards to get the original data.
 	shardSize := len(shards[0])
 	combined := make([]byte, 0, shardSize*s.dataShards)
 

--- a/internal/encoding/shards.go
+++ b/internal/encoding/shards.go
@@ -12,16 +12,16 @@ type Shards interface {
 }
 
 type shards struct {
-	dataShards	int
-	parityShards	int
-	totalShards	int
+	dataShards   int
+	parityShards int
+	totalShards  int
 }
 
 func NewShards(dataShards, parityShards int) *shards {
 	return &shards{
-		dataShards:	dataShards,
-		parityShards:	parityShards,
-		totalShards:	dataShards + parityShards,
+		dataShards:   dataShards,
+		parityShards: parityShards,
+		totalShards:  dataShards + parityShards,
 	}
 }
 
@@ -63,7 +63,6 @@ func (s *shards) Combine(shards [][]byte) []byte {
 	shardSize := len(shards[0])
 	totalSize := shardSize * len(shards)
 	result := make([]byte, totalSize)
-
 	for i, shard := range shards {
 		start := i * shardSize
 		copy(result[start:start+shardSize], shard)
@@ -79,7 +78,6 @@ func (s *shards) Extract(shards [][]byte) ([]byte, error) {
 
 	shardSize := len(shards[0])
 	combined := make([]byte, 0, shardSize*s.dataShards)
-
 	for i := 0; i < s.dataShards; i++ {
 		combined = append(combined, shards[i]...)
 	}

--- a/internal/files/file_manager.go
+++ b/internal/files/file_manager.go
@@ -1,3 +1,4 @@
+// Package files provides file management functionalities.
 package files
 
 import (
@@ -12,6 +13,7 @@ import (
 	"github.com/hambosto/sweetbyte/internal/utils"
 )
 
+// FileInfo represents information about a file.
 type FileInfo struct {
 	Path        string
 	Size        int64
@@ -19,31 +21,47 @@ type FileInfo struct {
 	IsEligible  bool
 }
 
+// FileManager defines the interface for file management.
 type FileManager interface {
+	// FindEligibleFiles finds files that are eligible for processing based on the given mode.
 	FindEligibleFiles(mode options.ProcessorMode) ([]string, error)
+	// IsEncryptedFile checks if a file is encrypted.
 	IsEncryptedFile(path string) bool
+	// GetOutputPath returns the output path for a given input path and processing mode.
 	GetOutputPath(inputPath string, mode options.ProcessorMode) string
+	// GetFileInfoList returns a list of FileInfo for the given files.
 	GetFileInfoList(files []string) ([]FileInfo, error)
+	// Remove removes a file with the given option.
 	Remove(path string, option options.DeleteOption) error
+	// CreateFile creates a new file.
 	CreateFile(path string) (*os.File, error)
+	// OpenFile opens a file for reading.
 	OpenFile(path string) (*os.File, os.FileInfo, error)
+	// GetFileInfo returns information about a file.
 	GetFileInfo(path string) (os.FileInfo, error)
+	// ValidatePath validates a file path.
 	ValidatePath(path string, mustExist bool) error
+	// ShowFileInfo displays information about a list of files.
 	ShowFileInfo(fileList []FileInfo)
+	// ShowProcessingInfo displays information about the file being processed.
 	ShowProcessingInfo(mode options.ProcessorMode, filePath string)
 }
 
+// fileManager implements the FileManager interface.
 type fileManager struct {
 	overwritePasses int
 }
 
+// NewFileManager creates a new FileManager.
 func NewFileManager(passes int) FileManager {
 	return &fileManager{overwritePasses: passes}
 }
 
+// FindEligibleFiles finds files that are eligible for processing based on the given mode.
 func (fm *fileManager) FindEligibleFiles(mode options.ProcessorMode) ([]string, error) {
 	var files []string
 
+	// Walk the current directory and find eligible files.
 	err := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -59,20 +77,27 @@ func (fm *fileManager) FindEligibleFiles(mode options.ProcessorMode) ([]string, 
 	return files, nil
 }
 
+// isEligible checks if a file is eligible for processing.
 func (fm *fileManager) isEligible(path string, info os.FileInfo, mode options.ProcessorMode) bool {
+	// Exclude directories, hidden files, and excluded files.
 	if info.IsDir() || strings.HasPrefix(info.Name(), ".") || fm.isExcluded(path) {
 		return false
 	}
+	// Check if the file is encrypted.
 	encrypted := strings.HasSuffix(path, config.FileExtension)
+	// Check if the file is eligible for the given mode.
 	return (mode == options.ModeEncrypt && !encrypted) || (mode == options.ModeDecrypt && encrypted)
 }
 
+// isExcluded checks if a file is in the excluded list.
 func (fm *fileManager) isExcluded(path string) bool {
+	// Check if the file is in an excluded directory.
 	for _, dir := range config.ExcludedDirs {
 		if strings.Contains(path, dir) {
 			return true
 		}
 	}
+	// Check if the file has an excluded extension.
 	for _, ext := range config.ExcludedExts {
 		if strings.HasSuffix(path, ext) {
 			return true
@@ -81,10 +106,12 @@ func (fm *fileManager) isExcluded(path string) bool {
 	return false
 }
 
+// IsEncryptedFile checks if a file is encrypted.
 func (fm *fileManager) IsEncryptedFile(path string) bool {
 	return strings.HasSuffix(path, config.FileExtension)
 }
 
+// GetOutputPath returns the output path for a given input path and processing mode.
 func (fm *fileManager) GetOutputPath(inputPath string, mode options.ProcessorMode) string {
 	if mode == options.ModeEncrypt {
 		return inputPath + config.FileExtension
@@ -92,9 +119,11 @@ func (fm *fileManager) GetOutputPath(inputPath string, mode options.ProcessorMod
 	return strings.TrimSuffix(inputPath, config.FileExtension)
 }
 
+// GetFileInfoList returns a list of FileInfo for the given files.
 func (fm *fileManager) GetFileInfoList(files []string) ([]FileInfo, error) {
 	var infos []FileInfo
 
+	// Get information for each file.
 	for _, f := range files {
 		stat, err := os.Stat(f)
 		if err != nil {
@@ -110,13 +139,16 @@ func (fm *fileManager) GetFileInfoList(files []string) ([]FileInfo, error) {
 	return infos, nil
 }
 
+// Remove removes a file with the given option.
 func (fm *fileManager) Remove(path string, opt options.DeleteOption) error {
 	path = filepath.Clean(path)
 
+	// Check if the file exists.
 	if err := fm.requireExists(path); err != nil {
 		return fmt.Errorf("cannot remove: %w", err)
 	}
 
+	// Remove the file based on the selected option.
 	switch opt {
 	case options.DeleteStandard:
 		return os.Remove(path)
@@ -127,21 +159,26 @@ func (fm *fileManager) Remove(path string, opt options.DeleteOption) error {
 	}
 }
 
+// CreateFile creates a new file.
 func (fm *fileManager) CreateFile(path string) (*os.File, error) {
 	path = filepath.Clean(path)
+	// Ensure the parent directory exists.
 	if err := fm.ensureParentDir(path); err != nil {
 		return nil, err
 	}
 	return os.Create(path)
 }
 
+// OpenFile opens a file for reading.
 func (fm *fileManager) OpenFile(path string) (*os.File, os.FileInfo, error) {
 	path = filepath.Clean(path)
 
+	// Open the file.
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, nil, fmt.Errorf("open failed: %w", err)
 	}
+	// Get file information.
 	info, err := f.Stat()
 	if err != nil {
 		return nil, nil, fmt.Errorf("stat failed: %w", err)
@@ -149,6 +186,7 @@ func (fm *fileManager) OpenFile(path string) (*os.File, os.FileInfo, error) {
 	return f, info, nil
 }
 
+// GetFileInfo returns information about a file.
 func (fm *fileManager) GetFileInfo(path string) (os.FileInfo, error) {
 	path = filepath.Clean(path)
 	stat, err := os.Stat(path)
@@ -161,12 +199,14 @@ func (fm *fileManager) GetFileInfo(path string) (os.FileInfo, error) {
 	return stat, nil
 }
 
+// ValidatePath validates a file path.
 func (fm *fileManager) ValidatePath(path string, mustExist bool) error {
 	info, err := fm.GetFileInfo(path)
 	if err != nil {
 		return err
 	}
 	if mustExist {
+		// Check if the file exists, is not a directory, and is not empty.
 		switch {
 		case info == nil:
 			return fmt.Errorf("file not found: %s", path)
@@ -176,43 +216,53 @@ func (fm *fileManager) ValidatePath(path string, mustExist bool) error {
 			return fmt.Errorf("file is empty: %s", path)
 		}
 	} else if info != nil {
+		// Check if the output file already exists.
 		return fmt.Errorf("output exists: %s", path)
 	}
 	return nil
 }
 
+// secureDelete securely deletes a file by overwriting it with random data.
 func (fm *fileManager) secureDelete(path string) error {
 	path = filepath.Clean(path)
+	// Open the file for writing.
 	f, err := os.OpenFile(path, os.O_WRONLY, 0)
 	if err != nil {
 		return fmt.Errorf("secure open failed: %w", err)
 	}
 	defer f.Close()
 
+	// Get file information.
 	stat, err := f.Stat()
 	if err != nil {
 		return fmt.Errorf("stat failed: %w", err)
 	}
 
+	// Overwrite the file with random data multiple times.
 	for i := 0; i < fm.overwritePasses; i++ {
 		if err := fm.overwriteRandom(f, stat.Size()); err != nil {
 			return fmt.Errorf("overwrite pass %d failed: %w", i+1, err)
 		}
 	}
 
+	// Remove the file.
 	if err := os.Remove(path); err != nil {
 		return fmt.Errorf("remove failed: %w", err)
 	}
 	return nil
 }
 
+// overwriteRandom overwrites a file with random data.
 func (fm *fileManager) overwriteRandom(f *os.File, size int64) error {
+	// Seek to the beginning of the file.
 	if _, err := f.Seek(0, 0); err != nil {
 		return fmt.Errorf("seek failed: %w", err)
 	}
+	// Create a buffer for random data.
 	buf := make([]byte, 4096)
 	left := size
 
+	// Write random data to the file in chunks.
 	for left > 0 {
 		chunk := min(left, int64(len(buf)))
 		if _, err := rand.Read(buf[:chunk]); err != nil {
@@ -226,6 +276,7 @@ func (fm *fileManager) overwriteRandom(f *os.File, size int64) error {
 	return f.Sync()
 }
 
+// requireExists checks if a file exists.
 func (fm *fileManager) requireExists(path string) error {
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {
@@ -236,6 +287,7 @@ func (fm *fileManager) requireExists(path string) error {
 	return nil
 }
 
+// ShowFileInfo displays information about a list of files.
 func (fm *fileManager) ShowFileInfo(files []FileInfo) {
 	if len(files) == 0 {
 		fmt.Println("No files found.")
@@ -253,6 +305,7 @@ func (fm *fileManager) ShowFileInfo(files []FileInfo) {
 	fmt.Println()
 }
 
+// ShowProcessingInfo displays information about the file being processed.
 func (fm *fileManager) ShowProcessingInfo(mode options.ProcessorMode, file string) {
 	action := "Encrypting"
 	if mode == options.ModeDecrypt {
@@ -263,6 +316,7 @@ func (fm *fileManager) ShowProcessingInfo(mode options.ProcessorMode, file strin
 	fmt.Println()
 }
 
+// ensureParentDir ensures that the parent directory of a file exists.
 func (fm *fileManager) ensureParentDir(path string) error {
 	dir := filepath.Dir(path)
 	if dir == "." || dir == "/" {

--- a/internal/files/file_manager.go
+++ b/internal/files/file_manager.go
@@ -1,4 +1,3 @@
-// Package files provides file system operations for the SweetByte application.
 package files
 
 import (
@@ -13,7 +12,6 @@ import (
 	"github.com/hambosto/sweetbyte/internal/utils"
 )
 
-// FileInfo holds metadata about a file.
 type FileInfo struct {
 	Path        string
 	Size        int64
@@ -21,7 +19,6 @@ type FileInfo struct {
 	IsEligible  bool
 }
 
-// FileManager defines the interface for file operations.
 type FileManager interface {
 	FindEligibleFiles(mode options.ProcessorMode) ([]string, error)
 	IsEncryptedFile(path string) bool
@@ -36,17 +33,14 @@ type FileManager interface {
 	ShowProcessingInfo(mode options.ProcessorMode, filePath string)
 }
 
-// fileManager implements FileManager and provides file utilities.
 type fileManager struct {
 	overwritePasses int
 }
 
-// NewManager returns a new FileManager with the given overwrite passes.
 func NewFileManager(passes int) FileManager {
 	return &fileManager{overwritePasses: passes}
 }
 
-// FindEligibleFiles scans the current directory for files eligible for the given mode.
 func (fm *fileManager) FindEligibleFiles(mode options.ProcessorMode) ([]string, error) {
 	var files []string
 
@@ -65,7 +59,6 @@ func (fm *fileManager) FindEligibleFiles(mode options.ProcessorMode) ([]string, 
 	return files, nil
 }
 
-// isEligible checks if a file can be processed based on mode and exclusions.
 func (fm *fileManager) isEligible(path string, info os.FileInfo, mode options.ProcessorMode) bool {
 	if info.IsDir() || strings.HasPrefix(info.Name(), ".") || fm.isExcluded(path) {
 		return false
@@ -74,7 +67,6 @@ func (fm *fileManager) isEligible(path string, info os.FileInfo, mode options.Pr
 	return (mode == options.ModeEncrypt && !encrypted) || (mode == options.ModeDecrypt && encrypted)
 }
 
-// isExcluded returns true if the path matches excluded dirs or extensions.
 func (fm *fileManager) isExcluded(path string) bool {
 	for _, dir := range config.ExcludedDirs {
 		if strings.Contains(path, dir) {
@@ -89,12 +81,10 @@ func (fm *fileManager) isExcluded(path string) bool {
 	return false
 }
 
-// IsEncryptedFile checks if the file ends with the encrypted extension.
 func (fm *fileManager) IsEncryptedFile(path string) bool {
 	return strings.HasSuffix(path, config.FileExtension)
 }
 
-// GetOutputPath returns the processed output path for the given mode.
 func (fm *fileManager) GetOutputPath(inputPath string, mode options.ProcessorMode) string {
 	if mode == options.ModeEncrypt {
 		return inputPath + config.FileExtension
@@ -102,7 +92,6 @@ func (fm *fileManager) GetOutputPath(inputPath string, mode options.ProcessorMod
 	return strings.TrimSuffix(inputPath, config.FileExtension)
 }
 
-// GetFileInfoList returns metadata for the given files.
 func (fm *fileManager) GetFileInfoList(files []string) ([]FileInfo, error) {
 	var infos []FileInfo
 
@@ -121,7 +110,6 @@ func (fm *fileManager) GetFileInfoList(files []string) ([]FileInfo, error) {
 	return infos, nil
 }
 
-// Remove deletes a file using the provided option.
 func (fm *fileManager) Remove(path string, opt options.DeleteOption) error {
 	path = filepath.Clean(path)
 
@@ -139,7 +127,6 @@ func (fm *fileManager) Remove(path string, opt options.DeleteOption) error {
 	}
 }
 
-// CreateFile creates a new file, ensuring parent directories exist.
 func (fm *fileManager) CreateFile(path string) (*os.File, error) {
 	path = filepath.Clean(path)
 	if err := fm.ensureParentDir(path); err != nil {
@@ -148,7 +135,6 @@ func (fm *fileManager) CreateFile(path string) (*os.File, error) {
 	return os.Create(path)
 }
 
-// OpenFile opens a file and returns its handle and info.
 func (fm *fileManager) OpenFile(path string) (*os.File, os.FileInfo, error) {
 	path = filepath.Clean(path)
 
@@ -163,7 +149,6 @@ func (fm *fileManager) OpenFile(path string) (*os.File, os.FileInfo, error) {
 	return f, info, nil
 }
 
-// GetFileInfo retrieves file info or nil if it does not exist.
 func (fm *fileManager) GetFileInfo(path string) (os.FileInfo, error) {
 	path = filepath.Clean(path)
 	stat, err := os.Stat(path)
@@ -176,7 +161,6 @@ func (fm *fileManager) GetFileInfo(path string) (os.FileInfo, error) {
 	return stat, nil
 }
 
-// ValidatePath validates a path for existence or non-existence.
 func (fm *fileManager) ValidatePath(path string, mustExist bool) error {
 	info, err := fm.GetFileInfo(path)
 	if err != nil {
@@ -197,14 +181,13 @@ func (fm *fileManager) ValidatePath(path string, mustExist bool) error {
 	return nil
 }
 
-// secureDelete overwrites and removes a file.
 func (fm *fileManager) secureDelete(path string) error {
 	path = filepath.Clean(path)
 	f, err := os.OpenFile(path, os.O_WRONLY, 0)
 	if err != nil {
 		return fmt.Errorf("secure open failed: %w", err)
 	}
-	defer f.Close() //nolint:errcheck
+	defer f.Close()
 
 	stat, err := f.Stat()
 	if err != nil {
@@ -223,7 +206,6 @@ func (fm *fileManager) secureDelete(path string) error {
 	return nil
 }
 
-// overwriteRandom writes random data across the file.
 func (fm *fileManager) overwriteRandom(f *os.File, size int64) error {
 	if _, err := f.Seek(0, 0); err != nil {
 		return fmt.Errorf("seek failed: %w", err)
@@ -244,7 +226,6 @@ func (fm *fileManager) overwriteRandom(f *os.File, size int64) error {
 	return f.Sync()
 }
 
-// requireExists ensures a file exists.
 func (fm *fileManager) requireExists(path string) error {
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {
@@ -255,7 +236,6 @@ func (fm *fileManager) requireExists(path string) error {
 	return nil
 }
 
-// ShowFileInfo prints metadata about files.
 func (fm *fileManager) ShowFileInfo(files []FileInfo) {
 	if len(files) == 0 {
 		fmt.Println("No files found.")
@@ -273,16 +253,16 @@ func (fm *fileManager) ShowFileInfo(files []FileInfo) {
 	fmt.Println()
 }
 
-// ShowProcessingInfo displays progress of current operation.
 func (fm *fileManager) ShowProcessingInfo(mode options.ProcessorMode, file string) {
 	action := "Encrypting"
 	if mode == options.ModeDecrypt {
 		action = "Decrypting"
 	}
-	fmt.Printf("\n%s file: %s\n", action, file)
+	fmt.Println()
+	fmt.Printf("%s file: %s", action, file)
+	fmt.Println()
 }
 
-// ensureParentDir creates parent directories if needed.
 func (fm *fileManager) ensureParentDir(path string) error {
 	dir := filepath.Dir(path)
 	if dir == "." || dir == "/" {

--- a/internal/header/deserializer.go
+++ b/internal/header/deserializer.go
@@ -1,3 +1,4 @@
+// Package header provides functionalities for handling file headers.
 package header
 
 import (
@@ -7,30 +8,37 @@ import (
 	"github.com/hambosto/sweetbyte/internal/utils"
 )
 
+// Unmarshal parses the header from the given reader and returns a Header struct.
 func Unmarshal(r io.Reader, key, magic, salt []byte) (*Header, error) {
+	// Ensure the key is not empty.
 	if len(key) == 0 {
 		return nil, fmt.Errorf("key cannot be empty")
 	}
 
+	// Read the header data.
 	headerData := make([]byte, 14)
 	if _, err := io.ReadFull(r, headerData); err != nil {
 		return nil, fmt.Errorf("failed to read header data: %w", err)
 	}
 
+	// Read the header MAC.
 	mac := make([]byte, MACSize)
 	if _, err := io.ReadFull(r, mac); err != nil {
 		return nil, fmt.Errorf("failed to read header MAC: %w", err)
 	}
 
+	// Verify the header MAC.
 	if err := verifyMAC(key, mac, magic, salt, headerData); err != nil {
 		return nil, err
 	}
 
+	// Deserialize the header data.
 	h, err := deserialize(headerData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to deserialize header: %w", err)
 	}
 
+	// Validate the header.
 	if err := h.validate(); err != nil {
 		return nil, err
 	}
@@ -38,11 +46,14 @@ func Unmarshal(r io.Reader, key, magic, salt []byte) (*Header, error) {
 	return h, nil
 }
 
+// deserialize converts a byte slice into a Header struct.
 func deserialize(data []byte) (*Header, error) {
+	// Ensure the data has the correct size.
 	if len(data) != 14 {
 		return nil, fmt.Errorf("invalid header data size: expected 14 bytes, got %d", len(data))
 	}
 
+	// Create a new Header from the data.
 	return &Header{
 		Version:      utils.FromBytes[uint16](data[0:2]),
 		Flags:        utils.FromBytes[uint32](data[2:6]),

--- a/internal/header/deserializer.go
+++ b/internal/header/deserializer.go
@@ -1,5 +1,3 @@
-// Package header provides functionality for creating, reading, and writing
-// authenticated file headers using direct struct serialization.
 package header
 
 import (
@@ -9,81 +7,45 @@ import (
 	"github.com/hambosto/sweetbyte/internal/utils"
 )
 
-// Unmarshal reads and deserializes an authenticated header from an io.Reader.
-// It verifies the integrity of the header using HMAC-SHA256 by re-calculating
-// the MAC with the provided key, magic bytes, and salt. If the MAC is valid,
-// it deserializes the header data into a Header struct.
-//
-// This function assumes that the magic bytes and salt have already been read
-// from the reader and are passed as arguments.
-//
-// The process is as follows:
-// 1. Read the fixed-size header data (14 bytes).
-// 2. Read the HMAC-SHA256 MAC (32 bytes).
-// 3. Verify the MAC by re-computing it using the key, magic bytes, salt, and header data.
-// 4. If the MAC is valid, deserialize the header data into a Header struct.
-// 5. Validate the fields of the deserialized header (e.g., version, original size).
-//
-// Returns a pointer to the deserialized Header struct or an error if any step fails.
 func Unmarshal(r io.Reader, key, magic, salt []byte) (*Header, error) {
-	// Ensure the key is not empty, as it's required for MAC verification.
 	if len(key) == 0 {
 		return nil, fmt.Errorf("key cannot be empty")
 	}
 
-	// Read the fixed-size header data (14 bytes). This contains the core metadata
-	// like version, flags, and original file size.
 	headerData := make([]byte, 14)
 	if _, err := io.ReadFull(r, headerData); err != nil {
 		return nil, fmt.Errorf("failed to read header data: %w", err)
 	}
 
-	// Read the MAC from the stream. The MAC is used to authenticate the header data.
 	mac := make([]byte, MACSize)
 	if _, err := io.ReadFull(r, mac); err != nil {
 		return nil, fmt.Errorf("failed to read header MAC: %w", err)
 	}
 
-	// Verify the integrity and authenticity of the header by re-calculating the MAC
-	// and comparing it with the one read from the stream.
 	if err := verifyMAC(key, mac, magic, salt, headerData); err != nil {
-		return nil, err // Return the error from verifyMAC directly.
+		return nil, err
 	}
 
-	// If the MAC is valid, deserialize the raw header data into a Header struct.
 	h, err := deserialize(headerData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to deserialize header: %w", err)
 	}
 
-	// Validate the contents of the deserialized header to ensure they are supported
-	// and within expected ranges (e.g., version check).
 	if err := h.validate(); err != nil {
 		return nil, err
 	}
 
-	// Return the fully validated and deserialized header.
 	return h, nil
 }
 
-// deserialize converts a 14-byte slice into a Header struct.
-// The byte slice is expected to have the following layout:
-// - Version (2 bytes, uint16)
-// - Flags (4 bytes, uint32)
-// - OriginalSize (8 bytes, uint64)
-//
-// This function uses utility functions to convert byte slices to their
-// corresponding integer types in a generic way.
 func deserialize(data []byte) (*Header, error) {
-	// Ensure the input data has the exact expected size for a serialized header.
 	if len(data) != 14 {
 		return nil, fmt.Errorf("invalid header data size: expected 14 bytes, got %d", len(data))
 	}
 
-	// Construct the Header struct by slicing the data and converting each part.
 	return &Header{
-		Version:      utils.FromBytes[uint16](data[0:2]),  // First 2 bytes for Version.
-		Flags:        utils.FromBytes[uint32](data[2:6]),  // Next 4 bytes for Flags.
-		OriginalSize: utils.FromBytes[uint64](data[6:14]), // Last 8 bytes for OriginalSize.
+		Version:      utils.FromBytes[uint16](data[0:2]),
+		Flags:        utils.FromBytes[uint32](data[2:6]),
+		OriginalSize: utils.FromBytes[uint64](data[6:14]),
 	}, nil
 }

--- a/internal/header/header.go
+++ b/internal/header/header.go
@@ -1,3 +1,4 @@
+// Package header provides functionalities for handling file headers.
 package header
 
 import (
@@ -9,29 +10,40 @@ import (
 )
 
 const (
+	// MagicBytes is the magic byte sequence for sweetbyte files.
 	MagicBytes = "SWX4"
-	MagicSize  = 4
-	MACSize    = 32
+	// MagicSize is the size of the magic byte sequence.
+	MagicSize = 4
+	// MACSize is the size of the header MAC.
+	MACSize = 32
 )
 
 const (
+	// CurrentVersion is the current version of the file format.
 	CurrentVersion uint16 = 0x0001
+	// FlagCompressed indicates that the file is compressed.
 	FlagCompressed uint32 = 1 << 0 // Bit 0
-	FlagEncrypted  uint32 = 1 << 1 // Bit 1
-	DefaultFlags          = FlagCompressed | FlagEncrypted
+	// FlagEncrypted indicates that the file is encrypted.
+	FlagEncrypted uint32 = 1 << 1 // Bit 1
+	// DefaultFlags is the default set of flags for a new header.
+	DefaultFlags = FlagCompressed | FlagEncrypted
 )
 
+// Header represents the file header.
 type Header struct {
 	Version      uint16
 	Flags        uint32
 	OriginalSize uint64
 }
 
+// NewHeader creates a new Header with the given original size.
 func NewHeader(originalSize uint64) (*Header, error) {
+	// Ensure the original size is not zero.
 	if originalSize == 0 {
 		return nil, fmt.Errorf("original size cannot be zero")
 	}
 
+	// Create a new header with default values.
 	return &Header{
 		Version:      CurrentVersion,
 		Flags:        DefaultFlags,
@@ -39,29 +51,35 @@ func NewHeader(originalSize uint64) (*Header, error) {
 	}, nil
 }
 
+// validate checks if the header is valid.
 func (h *Header) validate() error {
+	// Check if the version is supported.
 	if h.Version > CurrentVersion {
 		return fmt.Errorf("unsupported version: %d (current: %d)", h.Version, CurrentVersion)
 	}
 
+	// Check if the original size is not zero.
 	if h.OriginalSize == 0 {
 		return fmt.Errorf("original size cannot be zero")
 	}
 	return nil
 }
 
+// ReadMagic reads the magic bytes from the given reader.
 func ReadMagic(r io.Reader) ([]byte, error) {
 	magic := make([]byte, MagicSize)
 	_, err := io.ReadFull(r, magic)
 	return magic, err
 }
 
+// ReadSalt reads the salt from the given reader.
 func ReadSalt(r io.Reader) ([]byte, error) {
 	salt := make([]byte, config.SaltSize)
 	_, err := io.ReadFull(r, salt)
 	return salt, err
 }
 
+// VerifyMagic checks if the given magic bytes are valid.
 func VerifyMagic(magic []byte) bool {
 	return bytes.Equal(magic, []byte(MagicBytes))
 }

--- a/internal/header/header.go
+++ b/internal/header/header.go
@@ -1,12 +1,3 @@
-// Package header provides functionality for creating, reading, and writing
-// authenticated file headers for the SweetByte application. The header contains
-// essential metadata for processing the file, such as version, flags for
-// compression and encryption, and the original file size.
-//
-// The header is designed to be fixed-size and is protected by an HMAC-SHA256
-// message authentication code (MAC) to ensure its integrity and authenticity.
-// This package handles the serialization and deserialization of the header,
-// as well as MAC computation and verification.
 package header
 
 import (
@@ -17,62 +8,30 @@ import (
 	"github.com/hambosto/sweetbyte/internal/config"
 )
 
-// Constants defining the structure and properties of the file header.
 const (
-	// MagicBytes is a 4-byte sequence ("SWX4") that identifies the file format.
-	// It serves as a quick check to ensure the file is of the expected type.
 	MagicBytes = "SWX4"
-
-	// MagicSize is the length of the magic byte sequence.
-	MagicSize = 4
-
-	// MACSize is the size of the HMAC-SHA256 output, which is 32 bytes.
-	// This is used for authenticating the header.
-	MACSize = 32
+	MagicSize  = 4
+	MACSize    = 32
 )
 
-// Flag constants define bitmasks for various processing options.
-// These flags are combined in the Header's Flags field.
 const (
-	// CurrentVersion represents the latest version of the file format.
 	CurrentVersion uint16 = 0x0001
-
-	// FlagCompressed indicates that the file content is compressed.
 	FlagCompressed uint32 = 1 << 0 // Bit 0
-
-	// FlagEncrypted indicates that the file content is encrypted.
-	FlagEncrypted uint32 = 1 << 1 // Bit 1
-
-	// DefaultFlags is the standard combination of flags for new files,
-	// enabling both compression and encryption by default.
-	DefaultFlags = FlagCompressed | FlagEncrypted
+	FlagEncrypted  uint32 = 1 << 1 // Bit 1
+	DefaultFlags          = FlagCompressed | FlagEncrypted
 )
 
-// Header represents the structured metadata of a SweetByte file.
-// The binary layout of this struct is fixed and predictable, ensuring
-// consistent serialization and deserialization across different systems.
-// The total size of the serialized header data is 14 bytes.
-//
-// The layout is as follows:
-// - Version (2 bytes): The file format version.
-// - Flags (4 bytes): Bitmask for processing options like compression and encryption.
-// - OriginalSize (8 bytes): The size of the original, uncompressed file.
 type Header struct {
-	Version      uint16 // File format version.
-	Flags        uint32 // Processing flags (e.g., compression, encryption).
-	OriginalSize uint64 // Original uncompressed file size in bytes.
+	Version      uint16
+	Flags        uint32
+	OriginalSize uint64
 }
 
-// NewHeader creates a new Header with default values and the specified original size.
-// It initializes the header with the current version and default flags.
-// The originalSize must be greater than zero.
 func NewHeader(originalSize uint64) (*Header, error) {
-	// The original size of the file is a critical piece of metadata, so it cannot be zero.
 	if originalSize == 0 {
 		return nil, fmt.Errorf("original size cannot be zero")
 	}
 
-	// Return a new Header instance populated with standard values.
 	return &Header{
 		Version:      CurrentVersion,
 		Flags:        DefaultFlags,
@@ -80,40 +39,29 @@ func NewHeader(originalSize uint64) (*Header, error) {
 	}, nil
 }
 
-// validate checks that the header contains valid and supported field values.
-// This is typically called after deserializing a header to ensure it's safe to use.
 func (h *Header) validate() error {
-	// Check if the header's version is newer than what this application supports.
 	if h.Version > CurrentVersion {
 		return fmt.Errorf("unsupported version: %d (current: %d)", h.Version, CurrentVersion)
 	}
-	// The original size must be a positive value.
+
 	if h.OriginalSize == 0 {
 		return fmt.Errorf("original size cannot be zero")
 	}
 	return nil
 }
 
-// ReadMagic reads the magic bytes from the given reader and returns them.
-// It expects to read exactly MagicSize bytes.
 func ReadMagic(r io.Reader) ([]byte, error) {
 	magic := make([]byte, MagicSize)
-	// io.ReadFull ensures that the entire buffer is filled.
 	_, err := io.ReadFull(r, magic)
 	return magic, err
 }
 
-// ReadSalt reads the salt from the given reader.
-// The salt size is determined by the application's configuration.
 func ReadSalt(r io.Reader) ([]byte, error) {
 	salt := make([]byte, config.SaltSize)
-	// io.ReadFull ensures that the entire buffer is filled.
 	_, err := io.ReadFull(r, salt)
 	return salt, err
 }
 
-// VerifyMagic compares the provided byte slice with the expected MagicBytes.
-// It returns true if they match, indicating a valid file format.
 func VerifyMagic(magic []byte) bool {
 	return bytes.Equal(magic, []byte(MagicBytes))
 }

--- a/internal/header/mac.go
+++ b/internal/header/mac.go
@@ -1,5 +1,3 @@
-// Package header provides functionality for creating, reading, and writing
-// authenticated file headers using direct struct serialization.
 package header
 
 import (
@@ -8,62 +6,30 @@ import (
 	"fmt"
 )
 
-// computeMAC calculates the HMAC-SHA256 of a series of byte slices.
-// It takes a secret key and a variable number of byte slices (parts) that
-// will be concatenated and authenticated. The function ensures that the key
-// is not empty and iteratively writes each part to the HMAC hash.
-//
-// This function is central to creating the message authentication code (MAC)
-// that protects the header's integrity.
-//
-// Returns the computed MAC as a byte slice or an error if the key is empty
-// or if writing to the HMAC fails.
 func computeMAC(key []byte, parts ...[]byte) ([]byte, error) {
-	// A key is required to compute the HMAC.
 	if len(key) == 0 {
 		return nil, fmt.Errorf("key cannot be empty")
 	}
 
-	// Create a new HMAC instance with SHA256 as the hash function and the provided key.
 	mac := hmac.New(sha256.New, key)
-
-	// Iterate over all the parts and write them to the HMAC hash.
-	// The order of parts is significant and must be consistent between
-	// MAC generation and verification.
 	for i, part := range parts {
 		if _, err := mac.Write(part); err != nil {
-			// If writing fails, return a descriptive error.
 			return nil, fmt.Errorf("failed to write part %d to HMAC: %w", i, err)
 		}
 	}
 
-	// Finalize the HMAC computation and return the resulting MAC.
 	return mac.Sum(nil), nil
 }
 
-// verifyMAC re-computes the HMAC for a set of parts and compares it with an
-// expected MAC in constant time. This constant-time comparison is crucial
-// to prevent timing attacks, where an attacker could infer information about
-// the expected MAC by measuring the time it takes for the comparison to complete.
-//
-// It first computes the expected MAC using the same key and parts, then uses
-// `hmac.Equal` for a secure comparison.
-//
-// Returns an error if the MACs do not match or if the computation of the
-// expected MAC fails.
 func verifyMAC(key, macToVerify []byte, parts ...[]byte) error {
-	// Re-compute the MAC using the same key and parts that were originally used.
 	expectedMAC, err := computeMAC(key, parts...)
 	if err != nil {
 		return fmt.Errorf("failed to compute expected MAC: %w", err)
 	}
 
-	// Compare the provided MAC with the re-computed MAC in constant time.
-	// This is critical for security.
 	if !hmac.Equal(macToVerify, expectedMAC) {
 		return fmt.Errorf("header MAC verification failed")
 	}
 
-	// If the MACs match, verification is successful.
 	return nil
 }

--- a/internal/header/mac.go
+++ b/internal/header/mac.go
@@ -1,3 +1,4 @@
+// Package header provides functionalities for handling file headers.
 package header
 
 import (
@@ -6,27 +7,35 @@ import (
 	"fmt"
 )
 
+// computeMAC computes the HMAC-SHA256 of the given parts using the given key.
 func computeMAC(key []byte, parts ...[]byte) ([]byte, error) {
+	// Ensure the key is not empty.
 	if len(key) == 0 {
 		return nil, fmt.Errorf("key cannot be empty")
 	}
 
+	// Create a new HMAC-SHA256 hasher.
 	mac := hmac.New(sha256.New, key)
+	// Write the parts to the hasher.
 	for i, part := range parts {
 		if _, err := mac.Write(part); err != nil {
 			return nil, fmt.Errorf("failed to write part %d to HMAC: %w", i, err)
 		}
 	}
 
+	// Return the computed MAC.
 	return mac.Sum(nil), nil
 }
 
+// verifyMAC verifies the HMAC-SHA256 of the given parts using the given key.
 func verifyMAC(key, macToVerify []byte, parts ...[]byte) error {
+	// Compute the expected MAC.
 	expectedMAC, err := computeMAC(key, parts...)
 	if err != nil {
 		return fmt.Errorf("failed to compute expected MAC: %w", err)
 	}
 
+	// Compare the expected MAC with the given MAC.
 	if !hmac.Equal(macToVerify, expectedMAC) {
 		return fmt.Errorf("header MAC verification failed")
 	}

--- a/internal/header/serializer.go
+++ b/internal/header/serializer.go
@@ -1,4 +1,3 @@
-// authenticated file headers using direct struct serialization.
 package header
 
 import (
@@ -8,75 +7,39 @@ import (
 	"github.com/hambosto/sweetbyte/internal/utils"
 )
 
-// Marshal serializes the Header struct into a byte slice that includes
-// authentication information. The resulting byte slice is structured to be
-// easily written to a file or stream.
-//
-// The structure of the marshaled header is as follows:
-// [MagicBytes (4 bytes)][Salt (variable size)][HeaderData (14 bytes)][MAC (32 bytes)]
-//
-// The process involves:
-// 1. Validating the header's fields.
-// 2. Serializing the core Header struct into a 14-byte slice.
-// 3. Computing an HMAC-SHA256 MAC over the magic bytes, salt, and serialized header data.
-// 4. Assembling the final byte slice in the correct order.
-//
-// This ensures that the header is both structured and authenticated, protecting
-// it from tampering.
 func (h *Header) Marshal(salt, key []byte) ([]byte, error) {
-	// First, validate the header's contents to ensure they are valid before serialization.
 	if err := h.validate(); err != nil {
 		return nil, fmt.Errorf("header validation failed: %w", err)
 	}
 
-	// Ensure the provided salt has the correct size as defined in the configuration.
 	if len(salt) != config.SaltSize {
 		return nil, fmt.Errorf("invalid salt size: expected %d bytes, got %d", config.SaltSize, len(salt))
 	}
 
-	// A key is required to compute the HMAC.
 	if len(key) == 0 {
 		return nil, fmt.Errorf("key cannot be empty")
 	}
 
-	// Serialize the header fields (Version, Flags, OriginalSize) into a binary format.
 	headerData := h.serialize()
-
-	// Compute the HMAC-SHA256 MAC. The MAC covers the magic bytes, salt, and the
-	// serialized header data. This authenticates the entire header block.
 	mac, err := computeMAC(key, []byte(MagicBytes), salt, headerData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute header MAC: %w", err)
 	}
 
-	// Assemble the final byte slice in the correct order.
-	// Pre-allocating the slice with the total size improves efficiency.
 	totalSize := MagicSize + len(salt) + len(headerData) + MACSize
 	result := make([]byte, 0, totalSize)
-	result = append(result, []byte(MagicBytes)...) // Prepend magic bytes.
-	result = append(result, salt...)               // Append the salt.
-	result = append(result, headerData...)         // Append the serialized header data.
-	result = append(result, mac...)                // Append the computed MAC.
+	result = append(result, []byte(MagicBytes)...)
+	result = append(result, salt...)
+	result = append(result, headerData...)
+	result = append(result, mac...)
 
 	return result, nil
 }
 
-// serialize converts the Header struct's fields into a 14-byte slice.
-// It uses utility functions to perform the conversion from integer types
-// to byte slices, likely using big-endian encoding for consistency.
-//
-// The layout of the returned byte slice is:
-// - Version (2 bytes)
-// - Flags (4 bytes)
-// - OriginalSize (8 bytes)
 func (h *Header) serialize() []byte {
-	// Initialize an empty byte slice that will be built up.
 	var data []byte
-
-	// Append the byte representation of each field in order.
 	data = append(data, utils.ToBytes(h.Version)...)
 	data = append(data, utils.ToBytes(h.Flags)...)
 	data = append(data, utils.ToBytes(h.OriginalSize)...)
-
 	return data
 }

--- a/internal/header/serializer.go
+++ b/internal/header/serializer.go
@@ -1,3 +1,4 @@
+// Package header provides functionalities for handling file headers.
 package header
 
 import (
@@ -7,25 +8,32 @@ import (
 	"github.com/hambosto/sweetbyte/internal/utils"
 )
 
+// Marshal converts the header into a byte slice.
 func (h *Header) Marshal(salt, key []byte) ([]byte, error) {
+	// Validate the header.
 	if err := h.validate(); err != nil {
 		return nil, fmt.Errorf("header validation failed: %w", err)
 	}
 
+	// Ensure the salt has the correct size.
 	if len(salt) != config.SaltSize {
 		return nil, fmt.Errorf("invalid salt size: expected %d bytes, got %d", config.SaltSize, len(salt))
 	}
 
+	// Ensure the key is not empty.
 	if len(key) == 0 {
 		return nil, fmt.Errorf("key cannot be empty")
 	}
 
+	// Serialize the header data.
 	headerData := h.serialize()
+	// Compute the header MAC.
 	mac, err := computeMAC(key, []byte(MagicBytes), salt, headerData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute header MAC: %w", err)
 	}
 
+	// Create the final header byte slice.
 	totalSize := MagicSize + len(salt) + len(headerData) + MACSize
 	result := make([]byte, 0, totalSize)
 	result = append(result, []byte(MagicBytes)...)
@@ -36,6 +44,7 @@ func (h *Header) Marshal(salt, key []byte) ([]byte, error) {
 	return result, nil
 }
 
+// serialize converts the header fields into a byte slice.
 func (h *Header) serialize() []byte {
 	var data []byte
 	data = append(data, utils.ToBytes(h.Version)...)

--- a/internal/interactive/interactive.go
+++ b/internal/interactive/interactive.go
@@ -1,3 +1,4 @@
+// Package interactive provides the interactive mode for the application.
 package interactive
 
 import (
@@ -11,13 +12,16 @@ import (
 	"github.com/hambosto/sweetbyte/internal/ui"
 )
 
+// Interactive handles the application's interactive mode logic.
 type Interactive struct {
 	fileManager    files.FileManager
 	fileOperations operations.FileOperations
 	prompt         ui.PromptInput
 }
 
+// NewInteractive creates a new Interactive instance with its dependencies.
 func NewInteractive() *Interactive {
+	// Initialize dependencies.
 	fileManager := files.NewFileManager(config.OverwritePasses)
 	fileOperations := operations.NewFileOperations(fileManager)
 	prompt := ui.NewPromptInput(config.PasswordMinLen)
@@ -28,41 +32,51 @@ func NewInteractive() *Interactive {
 	}
 }
 
+// Run starts the interactive mode.
 func (a *Interactive) Run() {
+	// Clear the screen, move the cursor to the top left, and print the banner.
 	ui.Clear()
 	ui.MoveTopLeft()
 	ui.PrintBanner()
 
+	// Run the interactive loop.
 	if err := a.runInteractiveLoop(); err != nil {
 		fmt.Printf("Application error: %v\n", err)
 		os.Exit(1)
 	}
 }
 
+// runInteractiveLoop runs the main loop of the interactive mode.
 func (a *Interactive) runInteractiveLoop() error {
+	// Get the desired operation from the user.
 	operation, err := a.prompt.GetProcessingMode()
 	if err != nil {
 		return fmt.Errorf("failed to get processing mode: %w", err)
 	}
 
+	// Find eligible files for the selected operation.
 	eligibleFiles, err := a.getEligibleFiles(operation)
 	if err != nil {
 		return err
 	}
 
+	// Get and display file information.
 	fileInfos, err := a.fileManager.GetFileInfoList(eligibleFiles)
 	if err != nil {
 		return fmt.Errorf("failed to get file information: %w", err)
 	}
 	a.fileManager.ShowFileInfo(fileInfos)
 
+	// Let the user choose a file to process.
 	selectedFile, err := a.prompt.ChooseFile(eligibleFiles)
 	if err != nil {
 		return fmt.Errorf("failed to select file: %w", err)
 	}
 
+	// Show processing information.
 	a.fileManager.ShowProcessingInfo(operation, selectedFile)
 
+	// Process the selected file.
 	if err := a.processFile(selectedFile, operation); err != nil {
 		return fmt.Errorf("failed to process file %s: %w", selectedFile, err)
 	}
@@ -70,12 +84,15 @@ func (a *Interactive) runInteractiveLoop() error {
 	return nil
 }
 
+// getEligibleFiles finds files that are eligible for the selected operation.
 func (a *Interactive) getEligibleFiles(operation options.ProcessorMode) ([]string, error) {
+	// Find eligible files.
 	eligibleFiles, err := a.fileManager.FindEligibleFiles(operation)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find eligible files: %w", err)
 	}
 
+	// Ensure there are eligible files.
 	if len(eligibleFiles) == 0 {
 		return nil, fmt.Errorf("no eligible files found for %s operation", operation)
 	}
@@ -83,19 +100,24 @@ func (a *Interactive) getEligibleFiles(operation options.ProcessorMode) ([]strin
 	return eligibleFiles, nil
 }
 
+// processFile processes the selected file.
 func (a *Interactive) processFile(inputPath string, mode options.ProcessorMode) error {
+	// Get the output path for the file.
 	outputPath := a.fileManager.GetOutputPath(inputPath, mode)
 
+	// Validate the source file.
 	if err := a.fileManager.ValidatePath(inputPath, true); err != nil {
 		return fmt.Errorf("source validation failed: %w", err)
 	}
 
+	// Check if the output file already exists and ask for confirmation to overwrite.
 	if err := a.fileManager.ValidatePath(outputPath, false); err != nil {
 		if confirm, confirmErr := a.prompt.ConfirmFileOverwrite(outputPath); confirmErr != nil || !confirm {
 			return fmt.Errorf("operation canceled by user")
 		}
 	}
 
+	// Process the file based on the selected mode.
 	var err error
 	switch mode {
 	case options.ModeEncrypt:
@@ -114,6 +136,7 @@ func (a *Interactive) processFile(inputPath string, mode options.ProcessorMode) 
 	fmt.Printf("File encrypted successfully: %s", outputPath)
 	fmt.Println()
 
+	// Ask the user if they want to delete the source file.
 	var fileType string
 	if mode == options.ModeEncrypt {
 		fileType = "original"
@@ -131,12 +154,15 @@ func (a *Interactive) processFile(inputPath string, mode options.ProcessorMode) 
 	return nil
 }
 
+// encryptFile encrypts the given file.
 func (a *Interactive) encryptFile(srcPath, destPath string) error {
+	// Get the encryption password from the user.
 	password, err := a.prompt.GetEncryptionPassword()
 	if err != nil {
 		return fmt.Errorf("password prompt failed: %w", err)
 	}
 
+	// Encrypt the file.
 	if err := a.fileOperations.Encrypt(srcPath, destPath, password); err != nil {
 		return fmt.Errorf("failed to encrypt %s: %w", srcPath, err)
 	}
@@ -144,12 +170,15 @@ func (a *Interactive) encryptFile(srcPath, destPath string) error {
 	return nil
 }
 
+// decryptFile decrypts the given file.
 func (a *Interactive) decryptFile(srcPath, destPath string) error {
+	// Get the decryption password from the user.
 	password, err := a.prompt.GetDecryptionPassword()
 	if err != nil {
 		return fmt.Errorf("password prompt failed: %w", err)
 	}
 
+	// Decrypt the file.
 	if err := a.fileOperations.Decrypt(srcPath, destPath, password); err != nil {
 		return fmt.Errorf("failed to decrypt %s: %w", srcPath, err)
 	}

--- a/internal/interactive/interactive.go
+++ b/internal/interactive/interactive.go
@@ -1,4 +1,3 @@
-// Package interactive provides the interactive mode for the SweetByte application.
 package interactive
 
 import (
@@ -12,14 +11,12 @@ import (
 	"github.com/hambosto/sweetbyte/internal/ui"
 )
 
-// Interactive represents the interactive application.
 type Interactive struct {
 	fileManager    files.FileManager
 	fileOperations operations.FileOperations
 	prompt         ui.PromptInput
 }
 
-// NewInteractive creates a new Interactive.
 func NewInteractive() *Interactive {
 	fileManager := files.NewFileManager(config.OverwritePasses)
 	fileOperations := operations.NewFileOperations(fileManager)
@@ -31,41 +28,34 @@ func NewInteractive() *Interactive {
 	}
 }
 
-// Run starts the interactive application.
 func (a *Interactive) Run() {
 	ui.Clear()
 	ui.MoveTopLeft()
 	ui.PrintBanner()
 
-	// Run the main interactive loop.
 	if err := a.runInteractiveLoop(); err != nil {
 		fmt.Printf("Application error: %v\n", err)
 		os.Exit(1)
 	}
 }
 
-// runInteractiveLoop runs the main interactive loop.
 func (a *Interactive) runInteractiveLoop() error {
-	// Get the desired operation from the user.
 	operation, err := a.prompt.GetProcessingMode()
 	if err != nil {
 		return fmt.Errorf("failed to get processing mode: %w", err)
 	}
 
-	// Get the list of eligible files for the selected operation.
 	eligibleFiles, err := a.getEligibleFiles(operation)
 	if err != nil {
 		return err
 	}
 
-	// Get file information for the eligible files.
 	fileInfos, err := a.fileManager.GetFileInfoList(eligibleFiles)
 	if err != nil {
 		return fmt.Errorf("failed to get file information: %w", err)
 	}
 	a.fileManager.ShowFileInfo(fileInfos)
 
-	// Let the user choose a file to process.
 	selectedFile, err := a.prompt.ChooseFile(eligibleFiles)
 	if err != nil {
 		return fmt.Errorf("failed to select file: %w", err)
@@ -73,7 +63,6 @@ func (a *Interactive) runInteractiveLoop() error {
 
 	a.fileManager.ShowProcessingInfo(operation, selectedFile)
 
-	// Process the selected file.
 	if err := a.processFile(selectedFile, operation); err != nil {
 		return fmt.Errorf("failed to process file %s: %w", selectedFile, err)
 	}
@@ -81,7 +70,6 @@ func (a *Interactive) runInteractiveLoop() error {
 	return nil
 }
 
-// getEligibleFiles gets the list of eligible files for the selected operation.
 func (a *Interactive) getEligibleFiles(operation options.ProcessorMode) ([]string, error) {
 	eligibleFiles, err := a.fileManager.FindEligibleFiles(operation)
 	if err != nil {
@@ -95,12 +83,9 @@ func (a *Interactive) getEligibleFiles(operation options.ProcessorMode) ([]strin
 	return eligibleFiles, nil
 }
 
-// processFile processes the selected file.
 func (a *Interactive) processFile(inputPath string, mode options.ProcessorMode) error {
-	// Get the output path for the file.
 	outputPath := a.fileManager.GetOutputPath(inputPath, mode)
 
-	// Validate the input and output paths.
 	if err := a.fileManager.ValidatePath(inputPath, true); err != nil {
 		return fmt.Errorf("source validation failed: %w", err)
 	}
@@ -111,7 +96,6 @@ func (a *Interactive) processFile(inputPath string, mode options.ProcessorMode) 
 		}
 	}
 
-	// Process the file based on the selected mode.
 	var err error
 	switch mode {
 	case options.ModeEncrypt:
@@ -130,7 +114,6 @@ func (a *Interactive) processFile(inputPath string, mode options.ProcessorMode) 
 	fmt.Printf("File encrypted successfully: %s", outputPath)
 	fmt.Println()
 
-	// Ask the user if they want to delete the source file.
 	var fileType string
 	if mode == options.ModeEncrypt {
 		fileType = "original"
@@ -148,15 +131,12 @@ func (a *Interactive) processFile(inputPath string, mode options.ProcessorMode) 
 	return nil
 }
 
-// encryptFile encrypts the selected file.
 func (a *Interactive) encryptFile(srcPath, destPath string) error {
-	// Get the encryption password from the user.
 	password, err := a.prompt.GetEncryptionPassword()
 	if err != nil {
 		return fmt.Errorf("password prompt failed: %w", err)
 	}
 
-	// Encrypt the file.
 	if err := a.fileOperations.Encrypt(srcPath, destPath, password); err != nil {
 		return fmt.Errorf("failed to encrypt %s: %w", srcPath, err)
 	}
@@ -164,15 +144,12 @@ func (a *Interactive) encryptFile(srcPath, destPath string) error {
 	return nil
 }
 
-// decryptFile decrypts the selected file.
 func (a *Interactive) decryptFile(srcPath, destPath string) error {
-	// Get the decryption password from the user.
 	password, err := a.prompt.GetDecryptionPassword()
 	if err != nil {
 		return fmt.Errorf("password prompt failed: %w", err)
 	}
 
-	// Decrypt the file.
 	if err := a.fileOperations.Decrypt(srcPath, destPath, password); err != nil {
 		return fmt.Errorf("failed to decrypt %s: %w", srcPath, err)
 	}

--- a/internal/kdf/derive.go
+++ b/internal/kdf/derive.go
@@ -1,3 +1,4 @@
+// Package kdf provides key derivation functionalities.
 package kdf
 
 import (
@@ -10,20 +11,27 @@ import (
 )
 
 const (
-	ArgonTime    uint32 = 8
-	ArgonMemory  uint32 = 128 * 1024
-	ArgonThreads uint8  = 8
+	// ArgonTime is the number of iterations for Argon2id.
+	ArgonTime = 8
+	// ArgonMemory is the memory usage in KiB for Argon2id.
+	ArgonMemory = 128 * 1024
+	// ArgonThreads is the number of threads for Argon2id.
+	ArgonThreads = 8
 )
 
+// Hash derives a key from a password and salt using Argon2id.
 func Hash(password, salt []byte) ([]byte, error) {
+	// Ensure the password is not empty.
 	if len(password) == 0 {
 		return nil, fmt.Errorf("password cannot be empty")
 	}
 
+	// Ensure the salt has the correct size.
 	if len(salt) != config.SaltSize {
 		return nil, fmt.Errorf("expected %d bytes, got %d", config.SaltSize, len(salt))
 	}
 
+	// Derive the key using Argon2id.
 	key := argon2.IDKey(
 		password,
 		salt,
@@ -36,6 +44,7 @@ func Hash(password, salt []byte) ([]byte, error) {
 	return key, nil
 }
 
+// GetRandomSalt generates a random salt of the given size.
 func GetRandomSalt(size int) ([]byte, error) {
 	salt := make([]byte, size)
 	if _, err := io.ReadFull(rand.Reader, salt); err != nil {

--- a/internal/kdf/derive.go
+++ b/internal/kdf/derive.go
@@ -1,4 +1,3 @@
-// Package kdf provides key derivation functionality.
 package kdf
 
 import (
@@ -11,27 +10,20 @@ import (
 )
 
 const (
-	// ArgonTime is the number of iterations for Argon2.
-	ArgonTime uint32 = 8
-	// ArgonMemory is the memory usage in KiB for Argon2.
-	ArgonMemory uint32 = 128 * 1024
-	// ArgonThreads is the number of threads for Argon2.
-	ArgonThreads uint8 = 8
+	ArgonTime    uint32 = 8
+	ArgonMemory  uint32 = 128 * 1024
+	ArgonThreads uint8  = 8
 )
 
-// Hash derives a key from a password and salt using Argon2.
 func Hash(password, salt []byte) ([]byte, error) {
-	// Password cannot be empty.
 	if len(password) == 0 {
 		return nil, fmt.Errorf("password cannot be empty")
 	}
 
-	// Salt must be the correct size.
 	if len(salt) != config.SaltSize {
 		return nil, fmt.Errorf("expected %d bytes, got %d", config.SaltSize, len(salt))
 	}
 
-	// Derive the key using Argon2.
 	key := argon2.IDKey(
 		password,
 		salt,
@@ -44,7 +36,6 @@ func Hash(password, salt []byte) ([]byte, error) {
 	return key, nil
 }
 
-// GetRandomSalt generates a random salt of the specified size.
 func GetRandomSalt(size int) ([]byte, error) {
 	salt := make([]byte, size)
 	if _, err := io.ReadFull(rand.Reader, salt); err != nil {

--- a/internal/operations/operations.go
+++ b/internal/operations/operations.go
@@ -155,6 +155,7 @@ func (o *fileOperations) Decrypt(srcPath, destPath, password string) error {
 		return fmt.Errorf("failed to create stream processor: %w", err)
 	}
 
+	// #nosec G115
 	if err := processor.Process(context.Background(), srcFile, destFile, int64(h.OriginalSize)); err != nil {
 		return fmt.Errorf("failed to process file: %w", err)
 	}

--- a/internal/options/mode.go
+++ b/internal/options/mode.go
@@ -1,25 +1,15 @@
-// Package options defines the different modes and options for the SweetByte application.
 package options
 
-// ProcessorMode defines the mode of operation for the processor.
-// It can be either encryption or decryption.
 type ProcessorMode string
 
 const (
-	// ModeEncrypt represents the encryption mode.
 	ModeEncrypt ProcessorMode = "Encrypt"
-	// ModeDecrypt represents the decryption mode.
 	ModeDecrypt ProcessorMode = "Decrypt"
 )
 
-// DeleteOption defines the type of delete operation to be performed.
 type DeleteOption string
 
 const (
-	// DeleteStandard represents a standard delete operation.
-	// This is faster but the data may be recoverable.
 	DeleteStandard DeleteOption = "Normal Delete (faster, but recoverable)"
-	// DeleteSecure represents a secure delete operation.
-	// This is slower but the data is unrecoverable.
-	DeleteSecure DeleteOption = "Secure Delete (slower, but unrecoverable)"
+	DeleteSecure   DeleteOption = "Secure Delete (slower, but unrecoverable)"
 )

--- a/internal/options/mode.go
+++ b/internal/options/mode.go
@@ -1,15 +1,22 @@
+// Package options provides the application's options.
 package options
 
+// ProcessorMode defines the processing mode.
 type ProcessorMode string
 
 const (
+	// ModeEncrypt is the encryption mode.
 	ModeEncrypt ProcessorMode = "Encrypt"
+	// ModeDecrypt is the decryption mode.
 	ModeDecrypt ProcessorMode = "Decrypt"
 )
 
+// DeleteOption defines the file deletion option.
 type DeleteOption string
 
 const (
+	// DeleteStandard is the standard deletion option.
 	DeleteStandard DeleteOption = "Normal Delete (faster, but recoverable)"
-	DeleteSecure   DeleteOption = "Secure Delete (slower, but unrecoverable)"
+	// DeleteSecure is the secure deletion option.
+	DeleteSecure DeleteOption = "Secure Delete (slower, but unrecoverable)"
 )

--- a/internal/options/processing.go
+++ b/internal/options/processing.go
@@ -1,18 +1,12 @@
-// Package options defines the different modes and options for the SweetByte application.
 package options
 
-// Processing defines the type of processing to be performed.
-// It can be either encryption or decryption.
 type Processing int
 
 const (
-	// Encryption represents the encryption processing type.
 	Encryption Processing = iota
-	// Decryption represents the decryption processing type.
 	Decryption
 )
 
-// String returns the string representation of the Processing type.
 func (p Processing) String() string {
 	switch p {
 	case Encryption:

--- a/internal/options/processing.go
+++ b/internal/options/processing.go
@@ -1,12 +1,17 @@
+// Package options provides the application's options.
 package options
 
+// Processing defines the processing type.
 type Processing int
 
 const (
+	// Encryption is the encryption processing type.
 	Encryption Processing = iota
+	// Decryption is the decryption processing type.
 	Decryption
 )
 
+// String returns the string representation of the processing type.
 func (p Processing) String() string {
 	switch p {
 	case Encryption:

--- a/internal/padding/padding.go
+++ b/internal/padding/padding.go
@@ -1,19 +1,26 @@
+// Package padding provides PKCS#7 padding functionalities.
 package padding
 
 import (
 	"fmt"
 )
 
+// Padding defines the interface for padding and unpadding data.
 type Padding interface {
+	// Pad adds PKCS#7 padding to the data.
 	Pad(data []byte) ([]byte, error)
+	// Unpad removes PKCS#7 padding from the data.
 	Unpad(data []byte) ([]byte, error)
 }
 
+// padding implements the Padding interface.
 type padding struct {
 	blockSize int
 }
 
+// NewPadding creates a new Padding instance with the given block size.
 func NewPadding(blockSize int) (Padding, error) {
+	// Ensure the block size is valid.
 	if blockSize <= 0 || blockSize > 255 {
 		return nil, fmt.Errorf("block size must be between 1 and 255, got %d", blockSize)
 	}
@@ -22,30 +29,40 @@ func NewPadding(blockSize int) (Padding, error) {
 	}, nil
 }
 
+// Pad adds PKCS#7 padding to the data.
 func (p *padding) Pad(data []byte) ([]byte, error) {
+	// Ensure the data is not nil.
 	if data == nil {
 		return nil, fmt.Errorf("data cannot be nil")
 	}
 
+	// Calculate the number of bytes to pad.
 	padding := p.blockSize - (len(data) % p.blockSize)
+	// Create the padding text.
 	padText := make([]byte, padding)
 	for i := range padText {
 		padText[i] = byte(padding)
 	}
 
+	// Append the padding text to the data.
 	return append(data, padText...), nil
 }
 
+// Unpad removes PKCS#7 padding from the data.
 func (p *padding) Unpad(data []byte) ([]byte, error) {
+	// Ensure the data is not empty.
 	if len(data) == 0 {
 		return nil, fmt.Errorf("data cannot be empty")
 	}
 
+	// Ensure the data length is a multiple of the block size.
 	if len(data)%p.blockSize != 0 {
 		return nil, fmt.Errorf("data length must be multiple of block size %d, got %d", p.blockSize, len(data))
 	}
 
+	// Get the padding length from the last byte.
 	padding := int(data[len(data)-1])
+	// Ensure the padding length is valid.
 	if padding == 0 || padding > p.blockSize {
 		return nil, fmt.Errorf("padding value must be between 1 and %d, got %d", p.blockSize, padding)
 	}
@@ -54,11 +71,13 @@ func (p *padding) Unpad(data []byte) ([]byte, error) {
 		return nil, fmt.Errorf("padding value %d exceeds data length %d", padding, len(data))
 	}
 
+	// Verify the padding bytes.
 	for i := len(data) - padding; i < len(data); i++ {
 		if data[i] != byte(padding) {
 			return nil, fmt.Errorf("invalid padding byte at position %d, expected %d got %d", i, padding, data[i])
 		}
 	}
 
+	// Return the unpadded data.
 	return data[:len(data)-padding], nil
 }

--- a/internal/padding/padding.go
+++ b/internal/padding/padding.go
@@ -1,24 +1,19 @@
-// Package padding provides PKCS#7 padding functionality.
 package padding
 
 import (
 	"fmt"
 )
 
-// Padding defines the interface for padding and unpadding data.
 type Padding interface {
 	Pad(data []byte) ([]byte, error)
 	Unpad(data []byte) ([]byte, error)
 }
 
-// padding handles PKCS#7 padding.
 type padding struct {
 	blockSize int
 }
 
-// NewPadding creates a new Padding instance with the given block size.
 func NewPadding(blockSize int) (Padding, error) {
-	// The block size must be between 1 and 255.
 	if blockSize <= 0 || blockSize > 255 {
 		return nil, fmt.Errorf("block size must be between 1 and 255, got %d", blockSize)
 	}
@@ -27,58 +22,43 @@ func NewPadding(blockSize int) (Padding, error) {
 	}, nil
 }
 
-// Pad adds PKCS#7 padding to the data.
 func (p *padding) Pad(data []byte) ([]byte, error) {
-	// Data cannot be nil.
 	if data == nil {
 		return nil, fmt.Errorf("data cannot be nil")
 	}
 
-	// Calculate the number of bytes to pad.
 	padding := p.blockSize - (len(data) % p.blockSize)
-	// Create the padding text.
 	padText := make([]byte, padding)
-
-	// Fill the padding text with the padding value.
 	for i := range padText {
 		padText[i] = byte(padding)
 	}
 
-	// Append the padding text to the data.
 	return append(data, padText...), nil
 }
 
-// Unpad removes PKCS#7 padding from the data.
 func (p *padding) Unpad(data []byte) ([]byte, error) {
-	// Data cannot be empty.
 	if len(data) == 0 {
 		return nil, fmt.Errorf("data cannot be empty")
 	}
 
-	// The data length must be a multiple of the block size.
 	if len(data)%p.blockSize != 0 {
 		return nil, fmt.Errorf("data length must be multiple of block size %d, got %d", p.blockSize, len(data))
 	}
 
-	// Get the padding value from the last byte.
 	padding := int(data[len(data)-1])
-	// The padding value must be valid.
 	if padding == 0 || padding > p.blockSize {
 		return nil, fmt.Errorf("padding value must be between 1 and %d, got %d", p.blockSize, padding)
 	}
 
-	// The padding value cannot be greater than the data length.
 	if padding > len(data) {
 		return nil, fmt.Errorf("padding value %d exceeds data length %d", padding, len(data))
 	}
 
-	// Check if the padding bytes are valid.
 	for i := len(data) - padding; i < len(data); i++ {
 		if data[i] != byte(padding) {
 			return nil, fmt.Errorf("invalid padding byte at position %d, expected %d got %d", i, padding, data[i])
 		}
 	}
 
-	// Return the data without the padding.
 	return data[:len(data)-padding], nil
 }

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -1,4 +1,3 @@
-// Package processor provides the core processing logic for encryption and decryption.
 package processor
 
 import (
@@ -11,53 +10,44 @@ import (
 	"github.com/hambosto/sweetbyte/internal/padding"
 )
 
-// Processor defines the interface for the core processing logic.
 type Processor interface {
 	Encrypt(data []byte) ([]byte, error)
 	Decrypt(data []byte) ([]byte, error)
 }
 
-// processor handles the multi-layered encryption and decryption process.
 type processor struct {
-	firstCipher  cipher.Cipher
-	secondCipher cipher.Cipher
+	firstCipher  cipher.AESCipher
+	secondCipher cipher.ChaCha20Cipher
 	encoder      encoding.Encoder
 	compressor   compression.Compressor
 	padding      padding.Padding
 }
 
-// NewProcessor creates a new Processor with the given key.
 func NewProcessor(key []byte) (Processor, error) {
-	// The key must be the correct size.
 	if len(key) < config.MasterKeySize {
 		return nil, fmt.Errorf("encryption key must be at least %d bytes long, got %d bytes", config.MasterKeySize, len(key))
 	}
 
-	// Initialize the first cipher (AES-256-GCM).
 	firstCipher, err := cipher.NewAESCipher(key[:32])
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize AES-256-GCM cipher: %w", err)
 	}
 
-	// Initialize the second cipher (XChaCha20-Poly1305).
-	secondCipher, err := cipher.NewXChaCha20Cipher(key[32:64])
+	secondCipher, err := cipher.NewChaCha20Cipher(key[32:64])
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize XChaCha20-Poly1305 cipher: %w", err)
 	}
 
-	// Initialize the Reed-Solomon encoder.
 	encoder, err := encoding.NewEncoder(config.DataShards, config.ParityShards)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize Reed-Solomon encoder: %w", err)
 	}
 
-	// Initialize the compressor.
 	compressor, err := compression.NewCompressor(compression.LevelBestCompression)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize compressor: %w", err)
 	}
 
-	// Initialize the padding.
 	padder, err := padding.NewPadding(config.PaddingSize)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize PKCS#7 padding: %w", err)
@@ -72,33 +62,27 @@ func NewProcessor(key []byte) (Processor, error) {
 	}, nil
 }
 
-// Encrypt encrypts the given data.
 func (p *processor) Encrypt(data []byte) ([]byte, error) {
-	// Compress the data.
 	compressed, err := p.compressor.Compress(data)
 	if err != nil {
 		return nil, fmt.Errorf("compression failed: %w", err)
 	}
 
-	// Pad the compressed data.
 	padded, err := p.padding.Pad(compressed)
 	if err != nil {
 		return nil, fmt.Errorf("padding failed: %w", err)
 	}
 
-	// Encrypt the padded data with the first cipher.
 	firstEncrypted, err := p.firstCipher.Encrypt(padded)
 	if err != nil {
 		return nil, fmt.Errorf("first encryption (AES-256-GCM) failed: %w", err)
 	}
 
-	// Encrypt the result with the second cipher.
 	secondEncrypted, err := p.secondCipher.Encrypt(firstEncrypted)
 	if err != nil {
 		return nil, fmt.Errorf("second encryption (XChaCha20-Poly1305) failed: %w", err)
 	}
 
-	// Encode the result with Reed-Solomon codes.
 	encoded, err := p.encoder.Encode(secondEncrypted)
 	if err != nil {
 		return nil, fmt.Errorf("Reed-Solomon encoding failed: %w", err)
@@ -107,33 +91,27 @@ func (p *processor) Encrypt(data []byte) ([]byte, error) {
 	return encoded, nil
 }
 
-// Decrypt decrypts the given data.
 func (p *processor) Decrypt(data []byte) ([]byte, error) {
-	// Decode the data with Reed-Solomon codes.
 	decoded, err := p.encoder.Decode(data)
 	if err != nil {
 		return nil, fmt.Errorf("Reed-Solomon decoding failed (data may be corrupted): %w", err)
 	}
 
-	// Decrypt the data with the second cipher.
 	firstDecrypted, err := p.secondCipher.Decrypt(decoded)
 	if err != nil {
 		return nil, fmt.Errorf("first decryption (XChaCha20-Poly1305) failed - possible tampering detected: %w", err)
 	}
 
-	// Decrypt the result with the first cipher.
 	secondDecrypted, err := p.firstCipher.Decrypt(firstDecrypted)
 	if err != nil {
 		return nil, fmt.Errorf("second decryption (AES-256-GCM) failed - possible tampering detected: %w", err)
 	}
 
-	// Unpad the result.
 	unpadded, err := p.padding.Unpad(secondDecrypted)
 	if err != nil {
 		return nil, fmt.Errorf("padding validation failed - possible tampering detected: %w", err)
 	}
 
-	// Decompress the result.
 	decompressed, err := p.compressor.Decompress(unpadded)
 	if err != nil {
 		return nil, fmt.Errorf("decompression failed - possible data corruption: %w", err)

--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -1,3 +1,4 @@
+// Package processor provides the core data processing functionalities.
 package processor
 
 import (
@@ -10,11 +11,15 @@ import (
 	"github.com/hambosto/sweetbyte/internal/padding"
 )
 
+// Processor defines the interface for data processing.
 type Processor interface {
+	// Encrypt encrypts the given data.
 	Encrypt(data []byte) ([]byte, error)
+	// Decrypt decrypts the given data.
 	Decrypt(data []byte) ([]byte, error)
 }
 
+// processor implements the Processor interface.
 type processor struct {
 	firstCipher  cipher.AESCipher
 	secondCipher cipher.ChaCha20Cipher
@@ -23,31 +28,38 @@ type processor struct {
 	padding      padding.Padding
 }
 
+// NewProcessor creates a new Processor with the given key.
 func NewProcessor(key []byte) (Processor, error) {
+	// Ensure the key has the required size.
 	if len(key) < config.MasterKeySize {
 		return nil, fmt.Errorf("encryption key must be at least %d bytes long, got %d bytes", config.MasterKeySize, len(key))
 	}
 
+	// Initialize the first cipher (AES-256-GCM).
 	firstCipher, err := cipher.NewAESCipher(key[:32])
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize AES-256-GCM cipher: %w", err)
 	}
 
+	// Initialize the second cipher (XChaCha20-Poly1305).
 	secondCipher, err := cipher.NewChaCha20Cipher(key[32:64])
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize XChaCha20-Poly1305 cipher: %w", err)
 	}
 
+	// Initialize the Reed-Solomon encoder.
 	encoder, err := encoding.NewEncoder(config.DataShards, config.ParityShards)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize Reed-Solomon encoder: %w", err)
 	}
 
+	// Initialize the compressor.
 	compressor, err := compression.NewCompressor(compression.LevelBestCompression)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize compressor: %w", err)
 	}
 
+	// Initialize the PKCS#7 padding.
 	padder, err := padding.NewPadding(config.PaddingSize)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize PKCS#7 padding: %w", err)
@@ -62,27 +74,33 @@ func NewProcessor(key []byte) (Processor, error) {
 	}, nil
 }
 
+// Encrypt encrypts the given data.
 func (p *processor) Encrypt(data []byte) ([]byte, error) {
+	// Compress the data.
 	compressed, err := p.compressor.Compress(data)
 	if err != nil {
 		return nil, fmt.Errorf("compression failed: %w", err)
 	}
 
+	// Pad the compressed data.
 	padded, err := p.padding.Pad(compressed)
 	if err != nil {
 		return nil, fmt.Errorf("padding failed: %w", err)
 	}
 
+	// Encrypt the padded data with the first cipher.
 	firstEncrypted, err := p.firstCipher.Encrypt(padded)
 	if err != nil {
 		return nil, fmt.Errorf("first encryption (AES-256-GCM) failed: %w", err)
 	}
 
+	// Encrypt the result with the second cipher.
 	secondEncrypted, err := p.secondCipher.Encrypt(firstEncrypted)
 	if err != nil {
 		return nil, fmt.Errorf("second encryption (XChaCha20-Poly1305) failed: %w", err)
 	}
 
+	// Encode the result with Reed-Solomon.
 	encoded, err := p.encoder.Encode(secondEncrypted)
 	if err != nil {
 		return nil, fmt.Errorf("Reed-Solomon encoding failed: %w", err)
@@ -91,27 +109,33 @@ func (p *processor) Encrypt(data []byte) ([]byte, error) {
 	return encoded, nil
 }
 
+// Decrypt decrypts the given data.
 func (p *processor) Decrypt(data []byte) ([]byte, error) {
+	// Decode the data with Reed-Solomon.
 	decoded, err := p.encoder.Decode(data)
 	if err != nil {
 		return nil, fmt.Errorf("Reed-Solomon decoding failed (data may be corrupted): %w", err)
 	}
 
+	// Decrypt the data with the second cipher.
 	firstDecrypted, err := p.secondCipher.Decrypt(decoded)
 	if err != nil {
 		return nil, fmt.Errorf("first decryption (XChaCha20-Poly1305) failed - possible tampering detected: %w", err)
 	}
 
+	// Decrypt the result with the first cipher.
 	secondDecrypted, err := p.firstCipher.Decrypt(firstDecrypted)
 	if err != nil {
 		return nil, fmt.Errorf("second decryption (AES-256-GCM) failed - possible tampering detected: %w", err)
 	}
 
+	// Unpad the result.
 	unpadded, err := p.padding.Unpad(secondDecrypted)
 	if err != nil {
 		return nil, fmt.Errorf("padding validation failed - possible tampering detected: %w", err)
 	}
 
+	// Decompress the result.
 	decompressed, err := p.compressor.Decompress(unpadded)
 	if err != nil {
 		return nil, fmt.Errorf("decompression failed - possible data corruption: %w", err)

--- a/internal/streaming/chunk_reader.go
+++ b/internal/streaming/chunk_reader.go
@@ -1,3 +1,4 @@
+// Package streaming provides functionalities for streaming data processing.
 package streaming
 
 import (
@@ -10,16 +11,20 @@ import (
 	"github.com/hambosto/sweetbyte/internal/utils"
 )
 
+// ChunkReader defines the interface for reading chunks from an input stream.
 type ChunkReader interface {
+	// ReadChunks reads chunks from the input stream and sends them to a channel.
 	ReadChunks(ctx context.Context, input io.Reader) (<-chan Task, <-chan error)
 }
 
+// chunkReader implements the ChunkReader interface.
 type chunkReader struct {
 	processing  options.Processing
 	chunkSize   int
 	concurrency int
 }
 
+// NewChunkReader creates a new ChunkReader.
 func NewChunkReader(processing options.Processing, chunkSize, concurrency int) ChunkReader {
 	return &chunkReader{
 		processing:  processing,
@@ -28,6 +33,7 @@ func NewChunkReader(processing options.Processing, chunkSize, concurrency int) C
 	}
 }
 
+// ReadChunks reads chunks from the input stream and sends them to a channel.
 func (r *chunkReader) ReadChunks(ctx context.Context, input io.Reader) (<-chan Task, <-chan error) {
 	taskChan := make(chan Task, r.concurrency)
 	errChan := make(chan error, 1)
@@ -38,6 +44,7 @@ func (r *chunkReader) ReadChunks(ctx context.Context, input io.Reader) (<-chan T
 
 		var err error
 
+		// Read chunks based on the processing type.
 		switch r.processing {
 		case options.Encryption:
 			err = r.readForEncryption(ctx, input, taskChan)
@@ -47,6 +54,7 @@ func (r *chunkReader) ReadChunks(ctx context.Context, input io.Reader) (<-chan T
 			err = fmt.Errorf("unknown processing type: %d", r.processing)
 		}
 
+		// Send any error to the error channel.
 		if err != nil && !errors.Is(err, context.Canceled) {
 			select {
 			case errChan <- err:
@@ -58,19 +66,20 @@ func (r *chunkReader) ReadChunks(ctx context.Context, input io.Reader) (<-chan T
 	return taskChan, errChan
 }
 
+// readForEncryption reads chunks for encryption.
 func (r *chunkReader) readForEncryption(ctx context.Context, reader io.Reader, tasks chan<- Task) error {
 	buffer := make([]byte, r.chunkSize)
 
 	var index uint64
 	for {
-
+		// Check for cancellation.
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-
 		}
 
+		// Read a chunk from the input stream.
 		n, err := reader.Read(buffer)
 		if err == io.EOF {
 			return nil
@@ -79,12 +88,14 @@ func (r *chunkReader) readForEncryption(ctx context.Context, reader io.Reader, t
 			return fmt.Errorf("failed to read input: %w", err)
 		}
 
+		// Create a new task with the chunk data.
 		task := Task{
 			Data:  make([]byte, n),
 			Index: index,
 		}
 		copy(task.Data, buffer[:n])
 
+		// Send the task to the channel.
 		select {
 		case tasks <- task:
 			index++
@@ -94,17 +105,19 @@ func (r *chunkReader) readForEncryption(ctx context.Context, reader io.Reader, t
 	}
 }
 
+// readForDecryption reads chunks for decryption.
 func (r *chunkReader) readForDecryption(ctx context.Context, reader io.Reader, tasks chan<- Task) error {
 	var index uint64
 
 	for {
-
+		// Check for cancellation.
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
 		}
 
+		// Read the chunk size.
 		chunkLen, err := r.readChunkSize(reader)
 		if err == io.EOF {
 			return nil
@@ -118,16 +131,19 @@ func (r *chunkReader) readForDecryption(ctx context.Context, reader io.Reader, t
 			continue
 		}
 
+		// Read the chunk data.
 		data, err := r.readChunkData(reader, chunkLen)
 		if err != nil {
 			return err
 		}
 
+		// Create a new task with the chunk data.
 		task := Task{
 			Data:  data,
 			Index: index,
 		}
 
+		// Send the task to the channel.
 		select {
 		case tasks <- task:
 			index++
@@ -137,6 +153,7 @@ func (r *chunkReader) readForDecryption(ctx context.Context, reader io.Reader, t
 	}
 }
 
+// readChunkSize reads the size of a chunk from the reader.
 func (r *chunkReader) readChunkSize(reader io.Reader) (uint32, error) {
 	var sizeBuffer [4]byte
 	_, err := io.ReadFull(reader, sizeBuffer[:])
@@ -146,6 +163,7 @@ func (r *chunkReader) readChunkSize(reader io.Reader) (uint32, error) {
 	return utils.FromBytes[uint32](sizeBuffer[:]), nil
 }
 
+// readChunkData reads the data of a chunk from the reader.
 func (r *chunkReader) readChunkData(reader io.Reader, length uint32) ([]byte, error) {
 	data := make([]byte, length)
 	if _, err := io.ReadFull(reader, data); err != nil {

--- a/internal/streaming/chunk_reader.go
+++ b/internal/streaming/chunk_reader.go
@@ -1,4 +1,3 @@
-// Package streaming provides the core functionality for streaming encryption and decryption.
 package streaming
 
 import (
@@ -11,20 +10,16 @@ import (
 	"github.com/hambosto/sweetbyte/internal/utils"
 )
 
-// ChunkReader reads data from an io.Reader and splits it into chunks for processing.
 type ChunkReader interface {
 	ReadChunks(ctx context.Context, input io.Reader) (<-chan Task, <-chan error)
 }
 
-// chunkReader reads data from an io.Reader and splits it into chunks for processing.
-// The reading strategy depends on whether the operation is encryption or decryption.
 type chunkReader struct {
 	processing  options.Processing
 	chunkSize   int
 	concurrency int
 }
 
-// NewChunkReader creates a new ChunkReader with the specified processing mode and chunk size.
 func NewChunkReader(processing options.Processing, chunkSize, concurrency int) ChunkReader {
 	return &chunkReader{
 		processing:  processing,
@@ -33,8 +28,6 @@ func NewChunkReader(processing options.Processing, chunkSize, concurrency int) C
 	}
 }
 
-// ReadChunks reads data from the input reader and sends it as tasks to a channel.
-// It runs in a separate goroutine and returns a channel for tasks and a channel for errors.
 func (r *chunkReader) ReadChunks(ctx context.Context, input io.Reader) (<-chan Task, <-chan error) {
 	taskChan := make(chan Task, r.concurrency)
 	errChan := make(chan error, 1)
@@ -44,7 +37,7 @@ func (r *chunkReader) ReadChunks(ctx context.Context, input io.Reader) (<-chan T
 		defer close(errChan)
 
 		var err error
-		// Determine the reading strategy based on the processing mode.
+
 		switch r.processing {
 		case options.Encryption:
 			err = r.readForEncryption(ctx, input, taskChan)
@@ -54,7 +47,6 @@ func (r *chunkReader) ReadChunks(ctx context.Context, input io.Reader) (<-chan T
 			err = fmt.Errorf("unknown processing type: %d", r.processing)
 		}
 
-		// If an error occurs (and it's not a context cancellation), send it to the error channel.
 		if err != nil && !errors.Is(err, context.Canceled) {
 			select {
 			case errChan <- err:
@@ -66,13 +58,12 @@ func (r *chunkReader) ReadChunks(ctx context.Context, input io.Reader) (<-chan T
 	return taskChan, errChan
 }
 
-// readForEncryption reads the input stream into fixed-size chunks for encryption.
 func (r *chunkReader) readForEncryption(ctx context.Context, reader io.Reader, tasks chan<- Task) error {
 	buffer := make([]byte, r.chunkSize)
 
 	var index uint64
 	for {
-		// Check for context cancellation before each read.
+
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -80,23 +71,20 @@ func (r *chunkReader) readForEncryption(ctx context.Context, reader io.Reader, t
 
 		}
 
-		// Read data into the buffer.
 		n, err := reader.Read(buffer)
 		if err == io.EOF {
-			return nil // End of file reached.
+			return nil
 		}
 		if err != nil {
 			return fmt.Errorf("failed to read input: %w", err)
 		}
 
-		// Create a task with the read data.
 		task := Task{
 			Data:  make([]byte, n),
 			Index: index,
 		}
 		copy(task.Data, buffer[:n])
 
-		// Send the task to the channel, or exit if the context is canceled.
 		select {
 		case tasks <- task:
 			index++
@@ -106,40 +94,35 @@ func (r *chunkReader) readForEncryption(ctx context.Context, reader io.Reader, t
 	}
 }
 
-// readForDecryption reads the input stream, which is expected to have a chunk size header before each chunk.
 func (r *chunkReader) readForDecryption(ctx context.Context, reader io.Reader, tasks chan<- Task) error {
 	var index uint64
 
 	for {
-		// Check for context cancellation.
+
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
 		}
 
-		// Read the size of the next chunk.
 		chunkLen, err := r.readChunkSize(reader)
 		if err == io.EOF {
-			return nil // End of file.
+			return nil
 		}
 
 		if err != nil {
 			return err
 		}
 
-		// If chunk length is zero, skip to the next one.
 		if chunkLen == 0 {
 			continue
 		}
 
-		// Read the chunk data based on the read size.
 		data, err := r.readChunkData(reader, chunkLen)
 		if err != nil {
 			return err
 		}
 
-		// Create and send the task.
 		task := Task{
 			Data:  data,
 			Index: index,
@@ -154,7 +137,6 @@ func (r *chunkReader) readForDecryption(ctx context.Context, reader io.Reader, t
 	}
 }
 
-// readChunkSize reads the 4-byte chunk size header from the reader.
 func (r *chunkReader) readChunkSize(reader io.Reader) (uint32, error) {
 	var sizeBuffer [4]byte
 	_, err := io.ReadFull(reader, sizeBuffer[:])
@@ -164,7 +146,6 @@ func (r *chunkReader) readChunkSize(reader io.Reader) (uint32, error) {
 	return utils.FromBytes[uint32](sizeBuffer[:]), nil
 }
 
-// readChunkData reads a chunk of a given length from the reader.
 func (r *chunkReader) readChunkData(reader io.Reader, length uint32) ([]byte, error) {
 	data := make([]byte, length)
 	if _, err := io.ReadFull(reader, data); err != nil {

--- a/internal/streaming/chunk_writer.go
+++ b/internal/streaming/chunk_writer.go
@@ -1,4 +1,3 @@
-// Package streaming provides the core functionality for streaming encryption and decryption.
 package streaming
 
 import (
@@ -11,21 +10,16 @@ import (
 	"github.com/hambosto/sweetbyte/internal/utils"
 )
 
-// ChunkWriter writes processed chunks to an io.Writer.
 type ChunkWriter interface {
 	WriteChunks(ctx context.Context, output io.Writer, results <-chan TaskResult) error
 }
 
-// chunkWriter writes processed chunks to an io.Writer.
-// It uses an OrderBuffer to ensure chunks are written in the correct sequence.
 type chunkWriter struct {
 	processing options.Processing
 	buffer     OrderBuffer
 	bar        ui.ProgressBar
 }
 
-// NewChunkWriter creates a new ChunkWriter.
-// It takes the processing mode (encryption/decryption) and an optional progress bar.
 func NewChunkWriter(processing options.Processing, bar ui.ProgressBar) ChunkWriter {
 	return &chunkWriter{
 		processing: processing,
@@ -34,41 +28,35 @@ func NewChunkWriter(processing options.Processing, bar ui.ProgressBar) ChunkWrit
 	}
 }
 
-// WriteChunks receives processed task results from a channel and writes them to the output writer.
-// It ensures that chunks are written in the correct order.
 func (w *chunkWriter) WriteChunks(ctx context.Context, output io.Writer, results <-chan TaskResult) error {
 	for {
 		select {
 		case result, ok := <-results:
-			// If the results channel is closed, flush any remaining buffered chunks and exit.
+
 			if !ok {
 				return w.flushRemaining(output)
 			}
 
-			// If a task resulted in an error, return it immediately.
 			if result.Err != nil {
 				return fmt.Errorf("processing chunk %d: %w", result.Index, result.Err)
 			}
 
-			// Add the result to the buffer and get any chunks that are now ready to be written.
 			ready := w.buffer.Add(result)
 			if err := w.writeResults(output, ready); err != nil {
 				return err
 			}
 		case <-ctx.Done():
-			// If the context is canceled, return the context error.
+
 			return ctx.Err()
 		}
 	}
 }
 
-// flushRemaining writes any chunks that are still in the buffer to the output.
 func (w *chunkWriter) flushRemaining(output io.Writer) error {
 	remaining := w.buffer.Flush()
 	return w.writeResults(output, remaining)
 }
 
-// writeResults iterates over a slice of task results and writes them to the output.
 func (w *chunkWriter) writeResults(output io.Writer, results []TaskResult) error {
 	for _, result := range results {
 		if err := w.writeResult(output, result); err != nil {
@@ -78,22 +66,17 @@ func (w *chunkWriter) writeResults(output io.Writer, results []TaskResult) error
 	return nil
 }
 
-// writeResult writes a single task result to the output.
-// For encryption, it prepends the chunk data with its size.
 func (w *chunkWriter) writeResult(output io.Writer, result TaskResult) error {
-	// For encryption, write the chunk size as a header before the data.
 	if w.processing == options.Encryption {
 		if err := w.writeChunkSize(output, len(result.Data)); err != nil {
 			return fmt.Errorf("writing chunk size: %w", err)
 		}
 	}
 
-	// Write the actual chunk data.
 	if _, err := output.Write(result.Data); err != nil {
 		return fmt.Errorf("writing chunk data: %w", err)
 	}
 
-	// If a progress bar is configured, update it with the size of the written chunk.
 	if w.bar != nil {
 		if err := w.bar.Add(int64(result.Size)); err != nil {
 			return fmt.Errorf("updating progress: %w", err)
@@ -103,9 +86,7 @@ func (w *chunkWriter) writeResult(output io.Writer, result TaskResult) error {
 	return nil
 }
 
-// writeChunkSize writes the size of a chunk as a 4-byte header to the output.
 func (w *chunkWriter) writeChunkSize(output io.Writer, size int) error {
-	// #nosec G115
 	buffer := utils.ToBytes(uint32(size))
 	if _, err := output.Write(buffer); err != nil {
 		return fmt.Errorf("chunk size write failed: %w", err)

--- a/internal/streaming/chunk_writer.go
+++ b/internal/streaming/chunk_writer.go
@@ -46,7 +46,6 @@ func (w *chunkWriter) WriteChunks(ctx context.Context, output io.Writer, results
 				return err
 			}
 		case <-ctx.Done():
-
 			return ctx.Err()
 		}
 	}

--- a/internal/streaming/chunk_writer.go
+++ b/internal/streaming/chunk_writer.go
@@ -101,6 +101,7 @@ func (w *chunkWriter) writeResult(output io.Writer, result TaskResult) error {
 
 // writeChunkSize writes the size of a chunk to the output stream.
 func (w *chunkWriter) writeChunkSize(output io.Writer, size int) error {
+	// #nosec G115
 	buffer := utils.ToBytes(uint32(size))
 	if _, err := output.Write(buffer); err != nil {
 		return fmt.Errorf("chunk size write failed: %w", err)

--- a/internal/streaming/chunk_writer.go
+++ b/internal/streaming/chunk_writer.go
@@ -1,3 +1,4 @@
+// Package streaming provides functionalities for streaming data processing.
 package streaming
 
 import (
@@ -10,16 +11,20 @@ import (
 	"github.com/hambosto/sweetbyte/internal/utils"
 )
 
+// ChunkWriter defines the interface for writing chunks to an output stream.
 type ChunkWriter interface {
+	// WriteChunks writes chunks from a channel to the output stream.
 	WriteChunks(ctx context.Context, output io.Writer, results <-chan TaskResult) error
 }
 
+// chunkWriter implements the ChunkWriter interface.
 type chunkWriter struct {
 	processing options.Processing
 	buffer     OrderBuffer
 	bar        ui.ProgressBar
 }
 
+// NewChunkWriter creates a new ChunkWriter.
 func NewChunkWriter(processing options.Processing, bar ui.ProgressBar) ChunkWriter {
 	return &chunkWriter{
 		processing: processing,
@@ -28,19 +33,22 @@ func NewChunkWriter(processing options.Processing, bar ui.ProgressBar) ChunkWrit
 	}
 }
 
+// WriteChunks writes chunks from a channel to the output stream.
 func (w *chunkWriter) WriteChunks(ctx context.Context, output io.Writer, results <-chan TaskResult) error {
 	for {
 		select {
 		case result, ok := <-results:
-
+			// If the channel is closed, flush the remaining results and return.
 			if !ok {
 				return w.flushRemaining(output)
 			}
 
+			// If there was an error processing the chunk, return it.
 			if result.Err != nil {
 				return fmt.Errorf("processing chunk %d: %w", result.Index, result.Err)
 			}
 
+			// Add the result to the order buffer and write any ready results.
 			ready := w.buffer.Add(result)
 			if err := w.writeResults(output, ready); err != nil {
 				return err
@@ -51,11 +59,13 @@ func (w *chunkWriter) WriteChunks(ctx context.Context, output io.Writer, results
 	}
 }
 
+// flushRemaining flushes any remaining results in the order buffer.
 func (w *chunkWriter) flushRemaining(output io.Writer) error {
 	remaining := w.buffer.Flush()
 	return w.writeResults(output, remaining)
 }
 
+// writeResults writes a slice of task results to the output stream.
 func (w *chunkWriter) writeResults(output io.Writer, results []TaskResult) error {
 	for _, result := range results {
 		if err := w.writeResult(output, result); err != nil {
@@ -65,17 +75,21 @@ func (w *chunkWriter) writeResults(output io.Writer, results []TaskResult) error
 	return nil
 }
 
+// writeResult writes a single task result to the output stream.
 func (w *chunkWriter) writeResult(output io.Writer, result TaskResult) error {
+	// If encrypting, write the chunk size before the data.
 	if w.processing == options.Encryption {
 		if err := w.writeChunkSize(output, len(result.Data)); err != nil {
 			return fmt.Errorf("writing chunk size: %w", err)
 		}
 	}
 
+	// Write the chunk data.
 	if _, err := output.Write(result.Data); err != nil {
 		return fmt.Errorf("writing chunk data: %w", err)
 	}
 
+	// Update the progress bar.
 	if w.bar != nil {
 		if err := w.bar.Add(int64(result.Size)); err != nil {
 			return fmt.Errorf("updating progress: %w", err)
@@ -85,6 +99,7 @@ func (w *chunkWriter) writeResult(output io.Writer, result TaskResult) error {
 	return nil
 }
 
+// writeChunkSize writes the size of a chunk to the output stream.
 func (w *chunkWriter) writeChunkSize(output io.Writer, size int) error {
 	buffer := utils.ToBytes(uint32(size))
 	if _, err := output.Write(buffer); err != nil {

--- a/internal/streaming/order_buffer.go
+++ b/internal/streaming/order_buffer.go
@@ -1,3 +1,4 @@
+// Package streaming provides functionalities for streaming data processing.
 package streaming
 
 import (
@@ -5,17 +6,22 @@ import (
 	"sync"
 )
 
+// OrderBuffer defines the interface for a buffer that maintains the order of task results.
 type OrderBuffer interface {
+	// Add adds a task result to the buffer and returns any results that are now in order.
 	Add(result TaskResult) []TaskResult
+	// Flush returns all remaining results in the buffer, in order.
 	Flush() []TaskResult
 }
 
+// orderBuffer implements the OrderBuffer interface.
 type orderBuffer struct {
 	mu      sync.Mutex
 	results map[uint64]TaskResult
 	next    uint64
 }
 
+// NewOrderBuffer creates a new OrderBuffer.
 func NewOrderBuffer() OrderBuffer {
 	return &orderBuffer{
 		results: make(map[uint64]TaskResult),
@@ -23,13 +29,16 @@ func NewOrderBuffer() OrderBuffer {
 	}
 }
 
+// Add adds a task result to the buffer and returns any results that are now in order.
 func (b *orderBuffer) Add(result TaskResult) []TaskResult {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	// Add the result to the map.
 	b.results[result.Index] = result
 	var ready []TaskResult
 
+	// Check for any in-order results that are now ready.
 	for {
 		if result, exists := b.results[b.next]; exists {
 			ready = append(ready, result)
@@ -43,6 +52,7 @@ func (b *orderBuffer) Add(result TaskResult) []TaskResult {
 	return ready
 }
 
+// Flush returns all remaining results in the buffer, in order.
 func (b *orderBuffer) Flush() []TaskResult {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -51,17 +61,21 @@ func (b *orderBuffer) Flush() []TaskResult {
 		return nil
 	}
 
+	// Get all the indices from the map.
 	indices := make([]uint64, 0, len(b.results))
 	for idx := range b.results {
 		indices = append(indices, idx)
 	}
 
+	// Sort the indices to ensure the results are in order.
 	slices.Sort(indices)
+	// Create a slice of results in the correct order.
 	results := make([]TaskResult, len(indices))
 	for i, idx := range indices {
 		results[i] = b.results[idx]
 	}
 
+	// Clear the map.
 	clear(b.results)
 	return results
 }

--- a/internal/streaming/order_buffer.go
+++ b/internal/streaming/order_buffer.go
@@ -1,4 +1,3 @@
-// Package streaming provides the core functionality for streaming encryption and decryption.
 package streaming
 
 import (
@@ -6,20 +5,17 @@ import (
 	"sync"
 )
 
-// OrderBuffer is a buffer that stores and retrieves task results in order.
 type OrderBuffer interface {
 	Add(result TaskResult) []TaskResult
 	Flush() []TaskResult
 }
 
-// orderBuffer is a buffer that stores and retrieves task results in order.
 type orderBuffer struct {
 	mu      sync.Mutex
 	results map[uint64]TaskResult
 	next    uint64
 }
 
-// NewOrderBuffer creates a new orderBuffer.
 func NewOrderBuffer() OrderBuffer {
 	return &orderBuffer{
 		results: make(map[uint64]TaskResult),
@@ -27,15 +23,13 @@ func NewOrderBuffer() OrderBuffer {
 	}
 }
 
-// Add adds a task result to the buffer and returns any ready results.
 func (b *orderBuffer) Add(result TaskResult) []TaskResult {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	// Add the result to the map.
 	b.results[result.Index] = result
 	var ready []TaskResult
-	// Check for consecutive results starting from the next expected index.
+
 	for {
 		if result, exists := b.results[b.next]; exists {
 			ready = append(ready, result)
@@ -49,30 +43,25 @@ func (b *orderBuffer) Add(result TaskResult) []TaskResult {
 	return ready
 }
 
-// Flush returns any remaining results in the buffer, in order.
 func (b *orderBuffer) Flush() []TaskResult {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	// If the buffer is empty, return nil.
 	if len(b.results) == 0 {
 		return nil
 	}
 
-	// Get the indices of the remaining results.
 	indices := make([]uint64, 0, len(b.results))
 	for idx := range b.results {
 		indices = append(indices, idx)
 	}
 
-	// Sort the indices to ensure the results are in order.
 	slices.Sort(indices)
 	results := make([]TaskResult, len(indices))
 	for i, idx := range indices {
 		results[i] = b.results[idx]
 	}
 
-	// Clear the buffer.
 	clear(b.results)
 	return results
 }

--- a/internal/streaming/stream_config.go
+++ b/internal/streaming/stream_config.go
@@ -1,3 +1,4 @@
+// Package streaming provides functionalities for streaming data processing.
 package streaming
 
 import (
@@ -8,6 +9,7 @@ import (
 	"github.com/hambosto/sweetbyte/internal/options"
 )
 
+// StreamConfig holds the configuration for a stream processor.
 type StreamConfig struct {
 	Key         []byte
 	Processing  options.Processing
@@ -15,18 +17,23 @@ type StreamConfig struct {
 	ChunkSize   int
 }
 
+// Validate checks if the stream configuration is valid.
 func (s *StreamConfig) Validate() error {
+	// Ensure the key has the required size.
 	if len(s.Key) != config.MasterKeySize {
 		return fmt.Errorf("key must be 64 bytes long")
 	}
 	return nil
 }
 
+// ApplyDefaults applies default values to the stream configuration.
 func (s *StreamConfig) ApplyDefaults() {
+	// If concurrency is not set, use the number of available CPUs.
 	if s.Concurrency <= 0 {
 		s.Concurrency = runtime.GOMAXPROCS(0)
 	}
 
+	// If chunk size is not set, use the default chunk size.
 	if s.ChunkSize <= 0 {
 		s.ChunkSize = config.DefaultChunkSize
 	}

--- a/internal/streaming/stream_config.go
+++ b/internal/streaming/stream_config.go
@@ -1,4 +1,3 @@
-// Package streaming provides the core functionality for streaming encryption and decryption.
 package streaming
 
 import (
@@ -9,7 +8,6 @@ import (
 	"github.com/hambosto/sweetbyte/internal/options"
 )
 
-// StreamConfig holds the configuration for the streaming process.
 type StreamConfig struct {
 	Key         []byte
 	Processing  options.Processing
@@ -17,22 +15,18 @@ type StreamConfig struct {
 	ChunkSize   int
 }
 
-// Validate checks if the StreamConfig is valid.
 func (s *StreamConfig) Validate() error {
-	// The key must be 64 bytes long.
 	if len(s.Key) != config.MasterKeySize {
 		return fmt.Errorf("key must be 64 bytes long")
 	}
 	return nil
 }
 
-// ApplyDefaults sets default values for the StreamConfig if they are not already set.
 func (s *StreamConfig) ApplyDefaults() {
-	// If concurrency is not set, use the number of CPU cores.
 	if s.Concurrency <= 0 {
 		s.Concurrency = runtime.GOMAXPROCS(0)
 	}
-	// If chunk size is not set, use the default chunk size.
+
 	if s.ChunkSize <= 0 {
 		s.ChunkSize = config.DefaultChunkSize
 	}

--- a/internal/streaming/stream_processor.go
+++ b/internal/streaming/stream_processor.go
@@ -1,4 +1,3 @@
-// Package streaming provides the core functionality for streaming encryption and decryption.
 package streaming
 
 import (
@@ -10,13 +9,11 @@ import (
 	"github.com/hambosto/sweetbyte/internal/ui"
 )
 
-// Task represents a chunk of data to be processed.
 type Task struct {
 	Data  []byte
 	Index uint64
 }
 
-// TaskResult represents the result of a processed task.
 type TaskResult struct {
 	Index uint64
 	Data  []byte
@@ -24,12 +21,10 @@ type TaskResult struct {
 	Err   error
 }
 
-// StreamProcessor handles the entire streaming process.
 type StreamProcessor interface {
 	Process(ctx context.Context, input io.Reader, output io.Writer, totalSize int64) error
 }
 
-// streamProcessor handles the entire streaming process.
 type streamProcessor struct {
 	streamConfig  StreamConfig
 	taskProcessor TaskProcessor
@@ -38,16 +33,12 @@ type streamProcessor struct {
 	pool          WorkerPool
 }
 
-// NewStreamProcessor creates a new streamProcessor with the given configuration.
 func NewStreamProcessor(config StreamConfig) (StreamProcessor, error) {
-	// Validate the configuration.
 	if err := config.Validate(); err != nil {
 		return nil, err
 	}
-	// Apply default values to the configuration.
 	config.ApplyDefaults()
 
-	// Create a new task processor.
 	taskProcessor, err := NewTaskProcessor(config.Key, config.Processing)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create task processor: %w", err)
@@ -61,45 +52,33 @@ func NewStreamProcessor(config StreamConfig) (StreamProcessor, error) {
 	}, nil
 }
 
-// Process starts the streaming process for the given input and output streams.
 func (s *streamProcessor) Process(ctx context.Context, input io.Reader, output io.Writer, totalSize int64) error {
-	// Ensure input and output streams are not nil.
 	if input == nil || output == nil {
 		return fmt.Errorf("input and output streams must not be nil")
 	}
 
-	// Create a new progress bar.
 	bar := ui.NewProgressBar(totalSize, s.streamConfig.Processing.String())
-	// Create a new chunk writer with the progress bar.
 	s.writer = NewChunkWriter(s.streamConfig.Processing, bar)
-	// Run the processing pipeline.
 	return s.runPipeline(ctx, input, output)
 }
 
-// runPipeline sets up and runs the streaming pipeline.
 func (s *streamProcessor) runPipeline(ctx context.Context, input io.Reader, output io.Writer) error {
-	// Create a new context for the pipeline.
 	pipelineCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// Read chunks from the input stream.
 	tasks, readerErr := s.reader.ReadChunks(pipelineCtx, input)
-	// Process the tasks using the worker pool.
 	results := s.pool.Process(pipelineCtx, tasks)
 
 	var writerErr error
 	var wg sync.WaitGroup
 
-	// Start a goroutine to write the results to the output stream.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		writerErr = s.writer.WriteChunks(pipelineCtx, output, results)
 	}()
-	// Wait for the writer to finish.
-	wg.Wait()
 
-	// Check for reader errors.
+	wg.Wait()
 	select {
 	case err := <-readerErr:
 		if err != nil {
@@ -109,13 +88,11 @@ func (s *streamProcessor) runPipeline(ctx context.Context, input io.Reader, outp
 	default:
 	}
 
-	// Check for writer errors.
 	if writerErr != nil {
 		cancel()
 		return fmt.Errorf("writer error: %w", writerErr)
 	}
 
-	// Check if the context was canceled.
 	if pipelineCtx.Err() != nil {
 		return fmt.Errorf("operation was canceled: %w", pipelineCtx.Err())
 	}

--- a/internal/streaming/stream_processor.go
+++ b/internal/streaming/stream_processor.go
@@ -1,3 +1,4 @@
+// Package streaming provides functionalities for streaming data processing.
 package streaming
 
 import (
@@ -9,11 +10,13 @@ import (
 	"github.com/hambosto/sweetbyte/internal/ui"
 )
 
+// Task represents a chunk of data to be processed.
 type Task struct {
 	Data  []byte
 	Index uint64
 }
 
+// TaskResult represents the result of a processed task.
 type TaskResult struct {
 	Index uint64
 	Data  []byte
@@ -21,10 +24,13 @@ type TaskResult struct {
 	Err   error
 }
 
+// StreamProcessor defines the interface for a stream processor.
 type StreamProcessor interface {
+	// Process processes the data from the input stream and writes the result to the output stream.
 	Process(ctx context.Context, input io.Reader, output io.Writer, totalSize int64) error
 }
 
+// streamProcessor implements the StreamProcessor interface.
 type streamProcessor struct {
 	streamConfig  StreamConfig
 	taskProcessor TaskProcessor
@@ -33,12 +39,15 @@ type streamProcessor struct {
 	pool          WorkerPool
 }
 
+// NewStreamProcessor creates a new StreamProcessor.
 func NewStreamProcessor(config StreamConfig) (StreamProcessor, error) {
+	// Validate and apply defaults to the configuration.
 	if err := config.Validate(); err != nil {
 		return nil, err
 	}
 	config.ApplyDefaults()
 
+	// Create a new task processor.
 	taskProcessor, err := NewTaskProcessor(config.Key, config.Processing)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create task processor: %w", err)
@@ -52,26 +61,34 @@ func NewStreamProcessor(config StreamConfig) (StreamProcessor, error) {
 	}, nil
 }
 
+// Process processes the data from the input stream and writes the result to the output stream.
 func (s *streamProcessor) Process(ctx context.Context, input io.Reader, output io.Writer, totalSize int64) error {
+	// Ensure the input and output streams are not nil.
 	if input == nil || output == nil {
 		return fmt.Errorf("input and output streams must not be nil")
 	}
 
+	// Create a new progress bar and chunk writer.
 	bar := ui.NewProgressBar(totalSize, s.streamConfig.Processing.String())
 	s.writer = NewChunkWriter(s.streamConfig.Processing, bar)
+	// Run the processing pipeline.
 	return s.runPipeline(ctx, input, output)
 }
 
+// runPipeline runs the processing pipeline.
 func (s *streamProcessor) runPipeline(ctx context.Context, input io.Reader, output io.Writer) error {
 	pipelineCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	// Read chunks from the input stream.
 	tasks, readerErr := s.reader.ReadChunks(pipelineCtx, input)
+	// Process the chunks in a worker pool.
 	results := s.pool.Process(pipelineCtx, tasks)
 
 	var writerErr error
 	var wg sync.WaitGroup
 
+	// Write the results to the output stream.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -79,6 +96,7 @@ func (s *streamProcessor) runPipeline(ctx context.Context, input io.Reader, outp
 	}()
 
 	wg.Wait()
+	// Check for any errors from the reader.
 	select {
 	case err := <-readerErr:
 		if err != nil {
@@ -88,11 +106,13 @@ func (s *streamProcessor) runPipeline(ctx context.Context, input io.Reader, outp
 	default:
 	}
 
+	// Check for any errors from the writer.
 	if writerErr != nil {
 		cancel()
 		return fmt.Errorf("writer error: %w", writerErr)
 	}
 
+	// Check if the operation was canceled.
 	if pipelineCtx.Err() != nil {
 		return fmt.Errorf("operation was canceled: %w", pipelineCtx.Err())
 	}

--- a/internal/streaming/task_pool.go
+++ b/internal/streaming/task_pool.go
@@ -1,3 +1,4 @@
+// Package streaming provides functionalities for streaming data processing.
 package streaming
 
 import (
@@ -8,16 +9,21 @@ import (
 	"github.com/hambosto/sweetbyte/internal/processor"
 )
 
+// TaskProcessor defines the interface for processing a task.
 type TaskProcessor interface {
+	// Process processes a single task.
 	Process(ctx context.Context, task Task) TaskResult
 }
 
+// taskProcessor implements the TaskProcessor interface.
 type taskProcessor struct {
 	processor  processor.Processor
 	processing options.Processing
 }
 
+// NewTaskProcessor creates a new TaskProcessor.
 func NewTaskProcessor(key []byte, processing options.Processing) (TaskProcessor, error) {
+	// Create a new data processor.
 	proc, err := processor.NewProcessor(key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create processor: %w", err)
@@ -29,7 +35,9 @@ func NewTaskProcessor(key []byte, processing options.Processing) (TaskProcessor,
 	}, nil
 }
 
+// Process processes a single task.
 func (tp *taskProcessor) Process(ctx context.Context, task Task) TaskResult {
+	// Check for cancellation.
 	select {
 	case <-ctx.Done():
 		return TaskResult{
@@ -42,6 +50,7 @@ func (tp *taskProcessor) Process(ctx context.Context, task Task) TaskResult {
 	var output []byte
 	var err error
 
+	// Process the task based on the processing type.
 	switch tp.processing {
 	case options.Encryption:
 		output, err = tp.processor.Encrypt(task.Data)
@@ -51,6 +60,7 @@ func (tp *taskProcessor) Process(ctx context.Context, task Task) TaskResult {
 		err = fmt.Errorf("unknown processing type: %d", tp.processing)
 	}
 
+	// Calculate the size for the progress bar.
 	size := tp.calculateProgressSize(task.Data, output)
 	return TaskResult{
 		Index: task.Index,
@@ -60,6 +70,7 @@ func (tp *taskProcessor) Process(ctx context.Context, task Task) TaskResult {
 	}
 }
 
+// calculateProgressSize calculates the size for the progress bar.
 func (tp *taskProcessor) calculateProgressSize(input, output []byte) int {
 	if tp.processing == options.Encryption {
 		return len(input)

--- a/internal/streaming/task_pool.go
+++ b/internal/streaming/task_pool.go
@@ -1,4 +1,3 @@
-// Package streaming provides the core functionality for streaming encryption and decryption.
 package streaming
 
 import (
@@ -9,20 +8,16 @@ import (
 	"github.com/hambosto/sweetbyte/internal/processor"
 )
 
-// TaskProcessor processes individual tasks (chunks of data).
 type TaskProcessor interface {
 	Process(ctx context.Context, task Task) TaskResult
 }
 
-// taskProcessor processes individual tasks (chunks of data).
 type taskProcessor struct {
 	processor  processor.Processor
 	processing options.Processing
 }
 
-// NewTaskProcessor creates a new TaskProcessor with the given key and processing type.
 func NewTaskProcessor(key []byte, processing options.Processing) (TaskProcessor, error) {
-	// Create a new processor.
 	proc, err := processor.NewProcessor(key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create processor: %w", err)
@@ -34,9 +29,7 @@ func NewTaskProcessor(key []byte, processing options.Processing) (TaskProcessor,
 	}, nil
 }
 
-// Process processes a single task.
 func (tp *taskProcessor) Process(ctx context.Context, task Task) TaskResult {
-	// Check if the context has been canceled.
 	select {
 	case <-ctx.Done():
 		return TaskResult{
@@ -49,7 +42,6 @@ func (tp *taskProcessor) Process(ctx context.Context, task Task) TaskResult {
 	var output []byte
 	var err error
 
-	// Perform the appropriate action based on the processing type.
 	switch tp.processing {
 	case options.Encryption:
 		output, err = tp.processor.Encrypt(task.Data)
@@ -59,7 +51,6 @@ func (tp *taskProcessor) Process(ctx context.Context, task Task) TaskResult {
 		err = fmt.Errorf("unknown processing type: %d", tp.processing)
 	}
 
-	// Calculate the size for progress reporting.
 	size := tp.calculateProgressSize(task.Data, output)
 	return TaskResult{
 		Index: task.Index,
@@ -69,8 +60,6 @@ func (tp *taskProcessor) Process(ctx context.Context, task Task) TaskResult {
 	}
 }
 
-// calculateProgressSize calculates the size of the data to be reported for progress.
-// For encryption, it's the input size; for decryption, it's the output size.
 func (tp *taskProcessor) calculateProgressSize(input, output []byte) int {
 	if tp.processing == options.Encryption {
 		return len(input)

--- a/internal/streaming/worker_pool.go
+++ b/internal/streaming/worker_pool.go
@@ -1,4 +1,3 @@
-// Package streaming provides the core functionality for streaming encryption and decryption.
 package streaming
 
 import (
@@ -6,18 +5,15 @@ import (
 	"sync"
 )
 
-// WorkerPool manages a pool of workers for processing tasks concurrently.
 type WorkerPool interface {
 	Process(ctx context.Context, tasks <-chan Task) <-chan TaskResult
 }
 
-// defaultWorkerPool manages a pool of workers for processing tasks concurrently.
 type workerPool struct {
 	processor   TaskProcessor
 	concurrency int
 }
 
-// NewWorkerPool creates a new workerPool with the given task processor and concurrency level.
 func NewWorkerPool(processor TaskProcessor, concurrency int) WorkerPool {
 	return &workerPool{
 		processor:   processor,
@@ -25,48 +21,42 @@ func NewWorkerPool(processor TaskProcessor, concurrency int) WorkerPool {
 	}
 }
 
-// Process starts the worker pool and processes tasks from the input channel.
-// It returns a channel of task results.
 func (p *workerPool) Process(ctx context.Context, tasks <-chan Task) <-chan TaskResult {
-	// Create a buffered channel for results.
 	results := make(chan TaskResult, p.concurrency)
 	go func() {
-		// Close the results channel when all workers are done.
 		defer close(results)
 		var wg sync.WaitGroup
-		// Start the workers.
+
 		for i := 0; i < p.concurrency; i++ {
 			wg.Add(1)
 			go p.worker(ctx, &wg, tasks, results)
 		}
 
-		// Wait for all workers to finish.
 		wg.Wait()
 	}()
 	return results
 }
 
-// worker is a single worker that processes tasks from the tasks channel and sends results to the results channel.
 func (p *workerPool) worker(ctx context.Context, wg *sync.WaitGroup, tasks <-chan Task, results chan<- TaskResult) {
 	defer wg.Done()
 	for {
 		select {
-		// Read a task from the tasks channel.
+
 		case task, ok := <-tasks:
-			// If the channel is closed, return.
+
 			if !ok {
 				return
 			}
-			// Process the task.
+
 			result := p.processor.Process(ctx, task)
-			// Send the result to the results channel.
+
 			select {
 			case results <- result:
-			// If the context is canceled, return.
+
 			case <-ctx.Done():
 				return
 			}
-		// If the context is canceled, return.
+
 		case <-ctx.Done():
 			return
 		}

--- a/internal/streaming/worker_pool.go
+++ b/internal/streaming/worker_pool.go
@@ -49,7 +49,6 @@ func (p *workerPool) worker(ctx context.Context, wg *sync.WaitGroup, tasks <-cha
 			}
 
 			result := p.processor.Process(ctx, task)
-
 			select {
 			case results <- result:
 

--- a/internal/streaming/worker_pool.go
+++ b/internal/streaming/worker_pool.go
@@ -1,3 +1,4 @@
+// Package streaming provides functionalities for streaming data processing.
 package streaming
 
 import (
@@ -5,15 +6,19 @@ import (
 	"sync"
 )
 
+// WorkerPool defines the interface for a worker pool that processes tasks concurrently.
 type WorkerPool interface {
+	// Process processes tasks from a channel and returns the results to a channel.
 	Process(ctx context.Context, tasks <-chan Task) <-chan TaskResult
 }
 
+// workerPool implements the WorkerPool interface.
 type workerPool struct {
 	processor   TaskProcessor
 	concurrency int
 }
 
+// NewWorkerPool creates a new WorkerPool.
 func NewWorkerPool(processor TaskProcessor, concurrency int) WorkerPool {
 	return &workerPool{
 		processor:   processor,
@@ -21,12 +26,14 @@ func NewWorkerPool(processor TaskProcessor, concurrency int) WorkerPool {
 	}
 }
 
+// Process processes tasks from a channel and returns the results to a channel.
 func (p *workerPool) Process(ctx context.Context, tasks <-chan Task) <-chan TaskResult {
 	results := make(chan TaskResult, p.concurrency)
 	go func() {
 		defer close(results)
 		var wg sync.WaitGroup
 
+		// Start the workers.
 		for i := 0; i < p.concurrency; i++ {
 			wg.Add(1)
 			go p.worker(ctx, &wg, tasks, results)
@@ -37,25 +44,25 @@ func (p *workerPool) Process(ctx context.Context, tasks <-chan Task) <-chan Task
 	return results
 }
 
+// worker is a worker goroutine that processes tasks.
 func (p *workerPool) worker(ctx context.Context, wg *sync.WaitGroup, tasks <-chan Task, results chan<- TaskResult) {
 	defer wg.Done()
 	for {
 		select {
-
+		// Read a task from the channel.
 		case task, ok := <-tasks:
-
+			// If the channel is closed, return.
 			if !ok {
 				return
 			}
 
+			// Process the task and send the result to the results channel.
 			result := p.processor.Process(ctx, task)
 			select {
 			case results <- result:
-
 			case <-ctx.Done():
 				return
 			}
-
 		case <-ctx.Done():
 			return
 		}

--- a/internal/ui/progress_bar.go
+++ b/internal/ui/progress_bar.go
@@ -1,19 +1,25 @@
+// Package ui provides user interface functionalities.
 package ui
 
 import (
 	"github.com/schollz/progressbar/v3"
 )
 
+// ProgressBar defines the interface for a progress bar.
 type ProgressBar interface {
+	// Add adds the given size to the progress bar.
 	Add(size int64) error
 }
 
+// progressBar implements the ProgressBar interface.
 type progressBar struct {
 	bar         *progressbar.ProgressBar
 	description string
 }
 
+// NewProgressBar creates a new ProgressBar.
 func NewProgressBar(totalSize int64, description string) ProgressBar {
+	// Create a new progress bar with the given options.
 	bar := progressbar.NewOptions64(
 		totalSize,
 		progressbar.OptionSetDescription(description),
@@ -30,6 +36,7 @@ func NewProgressBar(totalSize int64, description string) ProgressBar {
 	}
 }
 
+// Add adds the given size to the progress bar.
 func (p *progressBar) Add(size int64) error {
 	return p.bar.Add64(size)
 }

--- a/internal/ui/progress_bar.go
+++ b/internal/ui/progress_bar.go
@@ -1,24 +1,19 @@
-// Package ui provides components for the user interface of the SweetByte application.
 package ui
 
 import (
 	"github.com/schollz/progressbar/v3"
 )
 
-// ProgressBar defines the interface for a progress bar.
 type ProgressBar interface {
 	Add(size int64) error
 }
 
-// progressBar is a wrapper around the progressbar library.
 type progressBar struct {
 	bar         *progressbar.ProgressBar
 	description string
 }
 
-// NewProgressBar creates a new ProgressBar instance.
 func NewProgressBar(totalSize int64, description string) ProgressBar {
-	// Initialize a new progress bar with the given options.
 	bar := progressbar.NewOptions64(
 		totalSize,
 		progressbar.OptionSetDescription(description),
@@ -35,7 +30,6 @@ func NewProgressBar(totalSize int64, description string) ProgressBar {
 	}
 }
 
-// Add adds the given size to the progress bar.
 func (p *progressBar) Add(size int64) error {
 	return p.bar.Add64(size)
 }

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -1,6 +1,3 @@
-// Package ui provides user interaction components for the SweetByte application.
-// It defines a prompt-based interface for confirming actions, selecting modes,
-// handling file operations, and securely gathering passwords.
 package ui
 
 import (
@@ -11,8 +8,6 @@ import (
 	"github.com/hambosto/sweetbyte/internal/options"
 )
 
-// PromptInput defines the interface for user interactions via prompts.
-// This abstraction allows SweetByte to swap prompt libraries or mock user input in tests.
 type PromptInput interface {
 	ConfirmFileOverwrite(path string) (bool, error)
 	GetEncryptionPassword() (string, error)
@@ -22,22 +17,18 @@ type PromptInput interface {
 	ChooseFile(fileList []string) (string, error)
 }
 
-// promptInput is the default implementation of PromptInput.
 type promptInput struct {
 	passwordMinLength int
 }
 
-// NewPromptInput returns a PromptInput with a minimum password length requirement.
 func NewPromptInput(passwordMinLength int) PromptInput {
 	return &promptInput{passwordMinLength: passwordMinLength}
 }
 
-// ConfirmFileOverwrite asks the user to confirm overwriting an existing file.
 func (p *promptInput) ConfirmFileOverwrite(path string) (bool, error) {
 	return p.confirm(fmt.Sprintf("Output file %s already exists. Overwrite?", path))
 }
 
-// GetEncryptionPassword prompts for a password, validates it, and requires confirmation.
 func (p *promptInput) GetEncryptionPassword() (string, error) {
 	password, err := p.getPassword("Enter encryption password:")
 	if err != nil {
@@ -57,7 +48,6 @@ func (p *promptInput) GetEncryptionPassword() (string, error) {
 	return password, nil
 }
 
-// GetDecryptionPassword prompts for a password used in decryption.
 func (p *promptInput) GetDecryptionPassword() (string, error) {
 	password, err := p.getPassword("Enter decryption password:")
 	if err != nil {
@@ -69,7 +59,6 @@ func (p *promptInput) GetDecryptionPassword() (string, error) {
 	return password, nil
 }
 
-// ConfirmFileRemoval asks the user to confirm file deletion and choose a deletion type.
 func (p *promptInput) ConfirmFileRemoval(path, fileType string) (bool, options.DeleteOption, error) {
 	confirm, err := p.confirm(fmt.Sprintf("Delete %s file %s?", fileType, path))
 	if err != nil {
@@ -89,7 +78,6 @@ func (p *promptInput) ConfirmFileRemoval(path, fileType string) (bool, options.D
 	return true, options.DeleteOption(deleteType), nil
 }
 
-// GetProcessingMode asks the user to select encryption or decryption.
 func (p *promptInput) GetProcessingMode() (options.ProcessorMode, error) {
 	mode, err := p.choose("Select operation:", []string{
 		string(options.ModeEncrypt),
@@ -101,12 +89,10 @@ func (p *promptInput) GetProcessingMode() (options.ProcessorMode, error) {
 	return options.ProcessorMode(mode), nil
 }
 
-// ChooseFile asks the user to pick a file from a list.
 func (p *promptInput) ChooseFile(fileList []string) (string, error) {
 	return p.choose("Select file:", fileList)
 }
 
-// getPassword securely prompts for a password (hidden input).
 func (p *promptInput) getPassword(message string) (string, error) {
 	var password string
 	err := huh.NewInput().Title(message).EchoMode(huh.EchoModePassword).Value(&password).WithTheme(huh.ThemeCatppuccin()).Run()
@@ -116,7 +102,6 @@ func (p *promptInput) getPassword(message string) (string, error) {
 	return password, nil
 }
 
-// validatePassword checks minimum length and non-empty requirements.
 func (p *promptInput) validatePassword(password string) error {
 	if len(password) < p.passwordMinLength {
 		return fmt.Errorf("password must be at least %d characters", p.passwordMinLength)
@@ -127,7 +112,6 @@ func (p *promptInput) validatePassword(password string) error {
 	return nil
 }
 
-// confirm presents a Yes/No choice and returns the boolean value.
 func (p *promptInput) confirm(message string) (bool, error) {
 	var confirm bool
 	err := huh.NewConfirm().Title(message).Value(&confirm).WithTheme(huh.ThemeCatppuccin()).Run()

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -1,3 +1,4 @@
+// Package ui provides user interface functionalities.
 package ui
 
 import (
@@ -8,36 +9,50 @@ import (
 	"github.com/hambosto/sweetbyte/internal/options"
 )
 
+// PromptInput defines the interface for user input prompts.
 type PromptInput interface {
+	// ConfirmFileOverwrite asks the user to confirm overwriting a file.
 	ConfirmFileOverwrite(path string) (bool, error)
+	// GetEncryptionPassword prompts the user for an encryption password.
 	GetEncryptionPassword() (string, error)
+	// GetDecryptionPassword prompts the user for a decryption password.
 	GetDecryptionPassword() (string, error)
+	// ConfirmFileRemoval asks the user to confirm removing a file.
 	ConfirmFileRemoval(path, fileType string) (bool, options.DeleteOption, error)
+	// GetProcessingMode prompts the user to select a processing mode.
 	GetProcessingMode() (options.ProcessorMode, error)
+	// ChooseFile prompts the user to choose a file from a list.
 	ChooseFile(fileList []string) (string, error)
 }
 
+// promptInput implements the PromptInput interface.
 type promptInput struct {
 	passwordMinLength int
 }
 
+// NewPromptInput creates a new PromptInput.
 func NewPromptInput(passwordMinLength int) PromptInput {
 	return &promptInput{passwordMinLength: passwordMinLength}
 }
 
+// ConfirmFileOverwrite asks the user to confirm overwriting a file.
 func (p *promptInput) ConfirmFileOverwrite(path string) (bool, error) {
 	return p.confirm(fmt.Sprintf("Output file %s already exists. Overwrite?", path))
 }
 
+// GetEncryptionPassword prompts the user for an encryption password.
 func (p *promptInput) GetEncryptionPassword() (string, error) {
+	// Get the password from the user.
 	password, err := p.getPassword("Enter encryption password:")
 	if err != nil {
 		return "", err
 	}
+	// Validate the password.
 	if err := p.validatePassword(password); err != nil {
 		return "", err
 	}
 
+	// Confirm the password.
 	confirm, err := p.getPassword("Confirm password:")
 	if err != nil {
 		return "", err
@@ -48,18 +63,23 @@ func (p *promptInput) GetEncryptionPassword() (string, error) {
 	return password, nil
 }
 
+// GetDecryptionPassword prompts the user for a decryption password.
 func (p *promptInput) GetDecryptionPassword() (string, error) {
+	// Get the password from the user.
 	password, err := p.getPassword("Enter decryption password:")
 	if err != nil {
 		return "", err
 	}
+	// Ensure the password is not empty.
 	if strings.TrimSpace(password) == "" {
 		return "", fmt.Errorf("password cannot be empty")
 	}
 	return password, nil
 }
 
+// ConfirmFileRemoval asks the user to confirm removing a file.
 func (p *promptInput) ConfirmFileRemoval(path, fileType string) (bool, options.DeleteOption, error) {
+	// Ask the user to confirm the removal.
 	confirm, err := p.confirm(fmt.Sprintf("Delete %s file %s?", fileType, path))
 	if err != nil {
 		return false, "", err
@@ -68,6 +88,7 @@ func (p *promptInput) ConfirmFileRemoval(path, fileType string) (bool, options.D
 		return false, "", nil
 	}
 
+	// Ask the user to choose a deletion type.
 	deleteType, err := p.choose("Select delete type:", []string{
 		string(options.DeleteStandard),
 		string(options.DeleteSecure),
@@ -78,7 +99,9 @@ func (p *promptInput) ConfirmFileRemoval(path, fileType string) (bool, options.D
 	return true, options.DeleteOption(deleteType), nil
 }
 
+// GetProcessingMode prompts the user to select a processing mode.
 func (p *promptInput) GetProcessingMode() (options.ProcessorMode, error) {
+	// Ask the user to choose an operation.
 	mode, err := p.choose("Select operation:", []string{
 		string(options.ModeEncrypt),
 		string(options.ModeDecrypt),
@@ -89,10 +112,12 @@ func (p *promptInput) GetProcessingMode() (options.ProcessorMode, error) {
 	return options.ProcessorMode(mode), nil
 }
 
+// ChooseFile prompts the user to choose a file from a list.
 func (p *promptInput) ChooseFile(fileList []string) (string, error) {
 	return p.choose("Select file:", fileList)
 }
 
+// getPassword prompts the user for a password.
 func (p *promptInput) getPassword(message string) (string, error) {
 	var password string
 	err := huh.NewInput().Title(message).EchoMode(huh.EchoModePassword).Value(&password).WithTheme(huh.ThemeCatppuccin()).Run()
@@ -102,16 +127,20 @@ func (p *promptInput) getPassword(message string) (string, error) {
 	return password, nil
 }
 
+// validatePassword validates the given password.
 func (p *promptInput) validatePassword(password string) error {
+	// Ensure the password meets the minimum length requirement.
 	if len(password) < p.passwordMinLength {
 		return fmt.Errorf("password must be at least %d characters", p.passwordMinLength)
 	}
+	// Ensure the password is not empty.
 	if strings.TrimSpace(password) == "" {
 		return fmt.Errorf("password cannot be empty")
 	}
 	return nil
 }
 
+// confirm displays a confirmation prompt to the user.
 func (p *promptInput) confirm(message string) (bool, error) {
 	var confirm bool
 	err := huh.NewConfirm().Title(message).Value(&confirm).WithTheme(huh.ThemeCatppuccin()).Run()
@@ -121,17 +150,21 @@ func (p *promptInput) confirm(message string) (bool, error) {
 	return confirm, nil
 }
 
+// choose displays a selection prompt to the user.
 func (p *promptInput) choose(title string, optionList []string) (string, error) {
+	// Ensure there are options to choose from.
 	if len(optionList) == 0 {
 		return "", fmt.Errorf("no options available for selection")
 	}
 
+	// Create the options for the select prompt.
 	var selected string
 	options := make([]huh.Option[string], len(optionList))
 	for i, option := range optionList {
 		options[i] = huh.NewOption(option, option)
 	}
 
+	// Run the select prompt.
 	err := huh.NewSelect[string]().Title(title).Options(options...).Value(&selected).WithTheme(huh.ThemeCatppuccin()).Run()
 	if err != nil {
 		return "", fmt.Errorf("selection failed: %w", err)

--- a/internal/ui/terminal.go
+++ b/internal/ui/terminal.go
@@ -1,3 +1,4 @@
+// Package ui provides user interface functionalities.
 package ui
 
 import (
@@ -6,21 +7,24 @@ import (
 	"github.com/inancgumus/screen"
 )
 
+// Clear clears the terminal screen.
 func Clear() {
 	screen.Clear()
 }
 
+// MoveTopLeft moves the cursor to the top-left corner of the terminal.
 func MoveTopLeft() {
 	screen.MoveTopLeft()
 }
 
+// PrintBanner prints the application banner to the terminal.
 func PrintBanner() {
 	banner := `
    _____                   __  ____        __     
   / ___/      _____  ___  / /_/ __ )__  __/ /____ 
   \__ \ | /| / / _ \/ _ \/ __/ __  / / / / __/ _ \
  ___/ / |/ |/ /  __/  __/ /_/ /_/ / /_/ / /_/  __/
-/____/|__/|__/\___/\___/\__/_____/\__, /\__/\___/ 
+/____/|__/|__/\___/\___/\__/_____/\__, /\__/
                                  /____/           
 `
 	fmt.Print(banner)

--- a/internal/ui/terminal.go
+++ b/internal/ui/terminal.go
@@ -1,4 +1,3 @@
-// Package ui provides components for the user interface of the SweetByte application.
 package ui
 
 import (
@@ -7,17 +6,14 @@ import (
 	"github.com/inancgumus/screen"
 )
 
-// Clear clears the terminal screen.
 func Clear() {
 	screen.Clear()
 }
 
-// MoveTopLeft moves the cursor to the top-left corner of the terminal.
 func MoveTopLeft() {
 	screen.MoveTopLeft()
 }
 
-// PrintBanner prints the application's banner to the terminal.
 func PrintBanner() {
 	banner := `
    _____                   __  ____        __     

--- a/internal/utils/bytes.go
+++ b/internal/utils/bytes.go
@@ -4,8 +4,6 @@ import (
 	"encoding/binary"
 )
 
-// ToBytes converts a fixed-size value to its big-endian byte representation.
-// It supports uint16, uint32, and uint64 types.
 func ToBytes(v any) []byte {
 	switch val := v.(type) {
 	case uint16:
@@ -24,8 +22,6 @@ func ToBytes(v any) []byte {
 	return nil
 }
 
-// FromBytes converts a byte slice to an unsigned integer type.
-// It supports uint16, uint32, and uint64.
 func FromBytes[T ~uint16 | ~uint32 | ~uint64](b []byte) T {
 	var zero T
 	switch any(zero).(type) {

--- a/internal/utils/bytes.go
+++ b/internal/utils/bytes.go
@@ -1,9 +1,11 @@
+// Package utils provides utility functions.
 package utils
 
 import (
 	"encoding/binary"
 )
 
+// ToBytes converts a uint16, uint32, or uint64 to a byte slice.
 func ToBytes(v any) []byte {
 	switch val := v.(type) {
 	case uint16:
@@ -22,6 +24,7 @@ func ToBytes(v any) []byte {
 	return nil
 }
 
+// FromBytes converts a byte slice to a uint16, uint32, or uint64.
 func FromBytes[T ~uint16 | ~uint32 | ~uint64](b []byte) T {
 	var zero T
 	switch any(zero).(type) {

--- a/internal/utils/format.go
+++ b/internal/utils/format.go
@@ -1,33 +1,24 @@
-// Package utils provides utility functions for the SweetByte application.
 package utils
 
 import (
 	"fmt"
 )
 
-// FormatBytes converts a byte count into a human-readable string.
-// It uses binary prefixes (KiB, MiB, etc.) for formatting.
 func FormatBytes(bytes int64) string {
-	// If the byte count is 0, return "0 B".
 	if bytes == 0 {
 		return "0 B"
 	}
 
-	// The base unit for conversion (1024 bytes).
 	const unit = 1024
-	// If the byte count is less than the unit, return it in bytes.
 	if bytes < unit {
 		return fmt.Sprintf("%d B", bytes)
 	}
 
-	// Initialize the divisor and exponent for calculation.
 	div, exp := int64(unit), 0
-	// Loop to find the correct unit (KiB, MiB, etc.).
 	for n := bytes / unit; n >= unit; n /= unit {
 		div *= unit
 		exp++
 	}
 
-	// Return the formatted string with the appropriate unit.
 	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
 }

--- a/internal/utils/format.go
+++ b/internal/utils/format.go
@@ -1,9 +1,11 @@
+// Package utils provides utility functions.
 package utils
 
 import (
 	"fmt"
 )
 
+// FormatBytes formats a byte count into a human-readable string.
 func FormatBytes(bytes int64) string {
 	if bytes == 0 {
 		return "0 B"

--- a/main.go
+++ b/main.go
@@ -1,3 +1,4 @@
+// Package main is the entry point of the SweetByte application.
 package main
 
 import (
@@ -7,13 +8,16 @@ import (
 	"github.com/hambosto/sweetbyte/cmd/interactive"
 )
 
+// main is the entry point of the application.
 func main() {
+	// If there are command-line arguments, run the CLI application.
 	if len(os.Args) > 1 {
 		cliApp := cli.NewCLI()
 		if err := cliApp.Execute(); err != nil {
 			os.Exit(1)
 		}
 	} else {
+		// Otherwise, run the interactive application.
 		interactiveApp := interactive.NewInteractive()
 		interactiveApp.Run()
 	}

--- a/main.go
+++ b/main.go
@@ -1,5 +1,3 @@
-// Package main is the entry point of the SweetByte application.
-// It determines whether to run the application in CLI mode or interactive mode based on the command-line arguments.
 package main
 
 import (
@@ -9,21 +7,14 @@ import (
 	"github.com/hambosto/sweetbyte/cmd/interactive"
 )
 
-// main is the entry point of the application.
-// It checks for command-line arguments to decide which mode to run.
 func main() {
-	// If there are more than one argument, it means the user wants to run the CLI mode.
 	if len(os.Args) > 1 {
-		// Create a new CLI application instance.
 		cliApp := cli.NewCLI()
-		// Execute the CLI application and exit with an error code if something goes wrong.
 		if err := cliApp.Execute(); err != nil {
 			os.Exit(1)
 		}
 	} else {
-		// If there are no arguments, run the application in interactiveApp mode.
 		interactiveApp := interactive.NewInteractive()
-		// Run the interactiveApp application.
 		interactiveApp.Run()
 	}
 }


### PR DESCRIPTION
Removes redundant package, struct, function, and constant comments across the entire codebase to improve readability and reduce noise.

Also refactors the internal cipher package by removing the generic 'Cipher' interface, introducing specific interfaces for AES and XChaCha20, and making their concrete implementations unexported.